### PR TITLE
feat(ui): split submit into metadata selector + submit

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -24,13 +24,14 @@
               "base": "dist/datasync"
             },
             "index": "src/index.html",
-            "polyfills": [
-              "src/polyfills.ts"
-            ],
+            "polyfills": ["src/polyfills.ts"],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["node_modules/bootstrap/dist/css/bootstrap.min.css", "src/styles.scss"],
+            "styles": [
+              "node_modules/bootstrap/dist/css/bootstrap.min.css",
+              "src/styles.scss"
+            ],
             "scripts": [
               "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
             ],
@@ -90,14 +91,15 @@
           "builder": "@angular/build:karma",
           "options": {
             "main": "src/test.ts",
-            "polyfills": [
-              "src/polyfills.ts"
-            ],
+            "polyfills": ["src/polyfills.ts"],
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
             "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["node_modules/bootstrap/dist/css/bootstrap.min.css", "src/styles.scss"],
+            "styles": [
+              "node_modules/bootstrap/dist/css/bootstrap.min.css",
+              "src/styles.scss"
+            ],
             "scripts": []
           }
         }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,31 +10,34 @@ export default [
   {
     rules: {
       // TypeScript specific rules (without type information)
-      "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_" },
+      ],
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/prefer-for-of": "error",
-      
+
       // General code quality rules
       "prefer-const": "error",
       "no-var": "error",
       "prefer-arrow-callback": "error",
       "prefer-template": "error",
-      "no-console": ["warn", { "allow": ["warn", "error"] }],
-      
+      "no-console": ["warn", { allow: ["warn", "error"] }],
+
       // Angular specific patterns
       "no-restricted-syntax": [
         "error",
         {
-          "selector": "CallExpression[callee.name='alert']",
-          "message": "Use proper notification system instead of alert()"
-        }
-      ]
-    }
+          selector: "CallExpression[callee.name='alert']",
+          message: "Use proper notification system instead of alert()",
+        },
+      ],
+    },
   },
   {
     files: ["src/**/*.spec.ts"],
     rules: {
-      "@typescript-eslint/no-explicit-any": "off"
-    }
-  }
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  },
 ];

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,7 +4,7 @@
 module.exports = function (config) {
   config.set({
     basePath: "",
-  frameworks: ["jasmine"],
+    frameworks: ["jasmine"],
     plugins: [
       require("karma-jasmine"),
       require("karma-chrome-launcher"),

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,7 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { PrimeNG } from 'primeng/config';
 

--- a/src/app/app.routs.ts
+++ b/src/app/app.routs.ts
@@ -19,6 +19,13 @@ export const routes: Routes = [
       import('./submit/submit.component').then((m) => m.SubmitComponent),
   },
   {
+    path: 'metadata-selector',
+    loadComponent: () =>
+      import('./metadata-selector/metadata-selector.component').then(
+        (m) => m.MetadataSelectorComponent,
+      ),
+  },
+  {
     path: 'compute',
     loadComponent: () =>
       import('./compute/compute.component').then((m) => m.ComputeComponent),

--- a/src/app/compare/compare.component.spec.ts
+++ b/src/app/compare/compare.component.spec.ts
@@ -1,5 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { CompareComponent } from './compare.component';

--- a/src/app/compare/compare.component.ts
+++ b/src/app/compare/compare.component.ts
@@ -1,5 +1,3 @@
- 
-
 // Author: Eryk Kulikowski @ KU Leuven (2023). Apache 2.0 License
 
 import { Component, OnInit, OnDestroy, inject } from '@angular/core';
@@ -39,7 +37,7 @@ import { FilterItem, SubscriptionManager } from '../shared/types';
   templateUrl: './compare.component.html',
   styleUrls: ['./compare.component.scss'],
   imports: [
-  CommonModule,
+    CommonModule,
     ButtonDirective,
     Ripple,
     TreeTableModule,
@@ -49,12 +47,16 @@ import { FilterItem, SubscriptionManager } from '../shared/types';
     DatafileComponent,
   ],
 })
-export class CompareComponent implements OnInit, OnDestroy, SubscriptionManager {
+export class CompareComponent
+  implements OnInit, OnDestroy, SubscriptionManager
+{
   private readonly dataUpdatesService = inject(DataUpdatesService);
   private readonly dataStateService = inject(DataStateService);
   private readonly credentialsService = inject(CredentialsService);
   private readonly router = inject(Router);
-  private readonly folderActionUpdateService = inject(FolderActionUpdateService);
+  private readonly folderActionUpdateService = inject(
+    FolderActionUpdateService,
+  );
   private readonly pluginService = inject(PluginService);
   private readonly utils = inject(UtilsService);
 
@@ -136,7 +138,7 @@ export class CompareComponent implements OnInit, OnDestroy, SubscriptionManager 
 
   ngOnDestroy(): void {
     // Clean up all subscriptions
-    this.subscriptions.forEach(sub => sub.unsubscribe());
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
     this.subscriptions.clear();
   }
 
@@ -317,7 +319,11 @@ export class CompareComponent implements OnInit, OnDestroy, SubscriptionManager 
 
   submit(): void {
     this.dataStateService.updateState(this.data);
-    this.router.navigate(['/submit']);
+    if (this.isNewDataset()) {
+      this.router.navigate(['/metadata-selector']);
+    } else {
+      this.router.navigate(['/submit']);
+    }
   }
 
   // UI helpers

--- a/src/app/compute/compute.component.spec.ts
+++ b/src/app/compute/compute.component.spec.ts
@@ -1,5 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 

--- a/src/app/compute/compute.component.ts
+++ b/src/app/compute/compute.component.ts
@@ -38,13 +38,7 @@ import { ExecutablefileComponent } from '../executablefile/executablefile.compon
 import { AutosizeModule } from 'ngx-autosize';
 
 // RxJS
-import {
-  debounceTime,
-  firstValueFrom,
-  map,
-  Observable,
-  Subject,
-} from 'rxjs';
+import { debounceTime, firstValueFrom, map, Observable, Subject } from 'rxjs';
 
 // Constants and types
 import { APP_CONSTANTS } from '../shared/constants';
@@ -69,7 +63,9 @@ import { SubscriptionManager } from '../shared/types';
     AutosizeModule,
   ],
 })
-export class ComputeComponent implements OnInit, OnDestroy, SubscriptionManager {
+export class ComputeComponent
+  implements OnInit, OnDestroy, SubscriptionManager
+{
   private readonly dvObjectLookupService = inject(DvObjectLookupService);
   private readonly pluginService = inject(PluginService);
   dataService = inject(DataService);
@@ -145,23 +141,23 @@ export class ComputeComponent implements OnInit, OnDestroy, SubscriptionManager 
               (err) =>
                 (this.doiItems = [
                   {
-                    label: `search failed: ${  err.message}`,
+                    label: `search failed: ${err.message}`,
                     value: err.message,
                   },
                 ]),
             ),
         error: (err) =>
           (this.doiItems = [
-            { label: `search failed: ${  err.message}`, value: err.message },
+            { label: `search failed: ${err.message}`, value: err.message },
           ]),
       });
   }
 
   ngOnDestroy(): void {
     // Clean up all subscriptions
-    this.subscriptions.forEach(sub => sub.unsubscribe());
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
     this.subscriptions.clear();
-    
+
     // Clean up existing observable subscriptions
     this.datasetSearchResultsSubscription?.unsubscribe();
   }
@@ -234,7 +230,7 @@ export class ComputeComponent implements OnInit, OnDestroy, SubscriptionManager 
       return;
     }
     this.doiItems = [
-      { label: `searching "${  searchTerm  }"...`, value: searchTerm },
+      { label: `searching "${searchTerm}"...`, value: searchTerm },
     ];
     this.datasetSearchSubject.next(searchTerm);
   }
@@ -267,7 +263,9 @@ export class ComputeComponent implements OnInit, OnDestroy, SubscriptionManager 
         },
         error: (err) => {
           subscription.unsubscribe();
-          this.notificationService.showError(`Getting executable files failed: ${err.error}`);
+          this.notificationService.showError(
+            `Getting executable files failed: ${err.error}`,
+          );
         },
       });
   }
@@ -338,7 +336,9 @@ export class ComputeComponent implements OnInit, OnDestroy, SubscriptionManager 
       error: (err) => {
         subscription.unsubscribe();
         this.loading = false;
-        this.notificationService.showError(`Getting computation results failed: ${err.error}`);
+        this.notificationService.showError(
+          `Getting computation results failed: ${err.error}`,
+        );
       },
     });
   }

--- a/src/app/connect/connect.component.spec.ts
+++ b/src/app/connect/connect.component.spec.ts
@@ -1,5 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';

--- a/src/app/connect/connect.component.ts
+++ b/src/app/connect/connect.component.ts
@@ -38,13 +38,7 @@ import { Skeleton } from 'primeng/skeleton';
 import { Tree } from 'primeng/tree';
 
 // RxJS
-import {
-  debounceTime,
-  firstValueFrom,
-  map,
-  Observable,
-  Subject,
-} from 'rxjs';
+import { debounceTime, firstValueFrom, map, Observable, Subject } from 'rxjs';
 
 // Constants and types
 import { APP_CONSTANTS } from '../shared/constants';
@@ -71,7 +65,9 @@ const new_dataset = 'New Dataset';
     Tree,
   ],
 })
-export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager {
+export class ConnectComponent
+  implements OnInit, OnDestroy, SubscriptionManager
+{
   private readonly router = inject(Router);
   private readonly dataStateService = inject(DataStateService);
   private readonly datasetService = inject(DatasetService);
@@ -172,14 +168,14 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
               (err) =>
                 (this.repoNames = [
                   {
-                    label: `search failed: ${  err.message}`,
+                    label: `search failed: ${err.message}`,
                     value: err.message,
                   },
                 ]),
             ),
         error: (err) =>
           (this.repoNames = [
-            { label: `search failed: ${  err.message}`, value: err.message },
+            { label: `search failed: ${err.message}`, value: err.message },
           ]),
       });
     this.collectionSearchResultsSubscription =
@@ -191,14 +187,14 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
               (err) =>
                 (this.collectionItems = [
                   {
-                    label: `search failed: ${  err.message}`,
+                    label: `search failed: ${err.message}`,
                     value: err.message,
                   },
                 ]),
             ),
         error: (err) =>
           (this.collectionItems = [
-            { label: `search failed: ${  err.message}`, value: err.message },
+            { label: `search failed: ${err.message}`, value: err.message },
           ]),
       });
     this.datasetSearchResultsSubscription =
@@ -210,14 +206,14 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
               (err) =>
                 (this.doiItems = [
                   {
-                    label: `search failed: ${  err.message}`,
+                    label: `search failed: ${err.message}`,
                     value: err.message,
                   },
                 ]),
             ),
         error: (err) =>
           (this.doiItems = [
-            { label: `search failed: ${  err.message}`, value: err.message },
+            { label: `search failed: ${err.message}`, value: err.message },
           ]),
       });
     this.route.queryParams.subscribe((params) => {
@@ -383,9 +379,9 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
 
   ngOnDestroy(): void {
     // Clean up all subscriptions
-    this.subscriptions.forEach(sub => sub.unsubscribe());
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
     this.subscriptions.clear();
-    
+
     // Clean up existing observable subscriptions
     this.repoSearchResultsSubscription?.unsubscribe();
     this.collectionSearchResultsSubscription?.unsubscribe();
@@ -446,14 +442,13 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
       if (url.includes('?')) {
         clId = '&client_id=';
       }
-      url =
-        `${url +
-        clId +
-        encodeURIComponent(tg.oauth_client_id) 
-        }&redirect_uri=${ 
-        encodeURIComponent(this.pluginService.getRedirectUri()) 
-        }&response_type=code&state=${ 
-        encodeURIComponent(JSON.stringify(loginState))}`;
+      url = `${
+        url + clId + encodeURIComponent(tg.oauth_client_id)
+      }&redirect_uri=${encodeURIComponent(
+        this.pluginService.getRedirectUri(),
+      )}&response_type=code&state=${encodeURIComponent(
+        JSON.stringify(loginState),
+      )}`;
       // + '&code_challenge=' + nonce + '&code_challenge_method=S256';
       if (scopes) {
         if (url.includes('scope=')) {
@@ -464,7 +459,7 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
           }
           url = url.replace(scopeStr, `scope=${encodeURIComponent(scopes)}`);
         } else {
-          url = `${url  }&scope=${  encodeURIComponent(scopes)}`;
+          url = `${url}&scope=${encodeURIComponent(scopes)}`;
         }
       }
       location.href = url;
@@ -598,14 +593,14 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
       const s = strings[i];
       if (s === undefined || s === '' || s === 'loading') {
         cnt++;
-        res = `${res  }\n- ${  names[i]}`;
+        res = `${res}\n- ${names[i]}`;
       }
     }
 
     const err = this.parseUrl();
     if (err) {
       cnt++;
-      res = `${res  }\n\n${  err}`;
+      res = `${res}\n\n${err}`;
     }
 
     if (cnt === 0) {
@@ -622,16 +617,34 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
     // Check basic required fields
     if (!this.pluginId || this.pluginId === 'loading') return false;
     if (!this.datasetId || this.datasetId === 'loading') return false;
-    
+
     // Check Dataverse token (required for connection)
-    if (this.showDVToken() && (!this.dataverseToken || this.dataverseToken.trim() === '')) return false;
+    if (
+      this.showDVToken() &&
+      (!this.dataverseToken || this.dataverseToken.trim() === '')
+    )
+      return false;
 
     // Check plugin-specific required fields
-    if (this.getSourceUrlFieldName() && (!this.sourceUrl || this.sourceUrl.trim() === '')) return false;
-    if (this.getTokenFieldName() && (!this.token || this.token.trim() === '')) return false;
-    if (this.getOptionFieldName() && (!this.option || this.option === 'loading')) return false;
-    if (this.getUsernameFieldName() && (!this.user || this.user.trim() === '')) return false;
-    if (this.getRepoNameFieldName() && (!this.getRepoName() || this.getRepoName()!.trim() === '')) return false;
+    if (
+      this.getSourceUrlFieldName() &&
+      (!this.sourceUrl || this.sourceUrl.trim() === '')
+    )
+      return false;
+    if (this.getTokenFieldName() && (!this.token || this.token.trim() === ''))
+      return false;
+    if (
+      this.getOptionFieldName() &&
+      (!this.option || this.option === 'loading')
+    )
+      return false;
+    if (this.getUsernameFieldName() && (!this.user || this.user.trim() === ''))
+      return false;
+    if (
+      this.getRepoNameFieldName() &&
+      (!this.getRepoName() || this.getRepoName()!.trim() === '')
+    )
+      return false;
 
     // Check URL parsing if applicable
     if (this.pluginService.getPlugin(this.pluginId).parseSourceUrlField) {
@@ -652,22 +665,22 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
    */
   private validateUrlParsing(): string | undefined {
     if (!this.sourceUrl) return 'Source URL is required';
-    
+
     let toSplit = this.sourceUrl;
     if (toSplit.endsWith('/')) {
       toSplit = toSplit.substring(0, toSplit.length - 1);
     }
-    
+
     const splitted = toSplit.split('://');
     if (splitted?.length !== 2) {
       return 'Malformed source url';
     }
-    
+
     const pathParts = splitted[1].split('/');
     if (pathParts?.length <= 2) {
       return 'Malformed source url';
     }
-    
+
     return undefined;
   }
 
@@ -683,7 +696,7 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
    */
   get connectButtonClass(): string {
     const baseClasses = 'p-button-sm p-button-raised';
-    return this.isConnectReady 
+    return this.isConnectReady
       ? `${baseClasses} p-button-primary`
       : `${baseClasses} p-button-secondary`;
   }
@@ -711,7 +724,7 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
     if (splitted?.length == 2) {
       splitted = splitted[1].split('/');
       if (splitted?.length > 2) {
-        this.url = `https://${  splitted[0]}`;
+        this.url = `https://${splitted[0]}`;
         this.repoName = splitted.slice(1, splitted.length).join('/');
         if (this.repoName.endsWith('.git')) {
           this.repoName = this.repoName.substring(0, this.repoName.length - 4);
@@ -819,7 +832,9 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
       this.getUsernameFieldName() &&
       (this.user === undefined || this.user === '')
     ) {
-      this.notificationService.showError(`${this.getUsernameFieldName()} is missing`);
+      this.notificationService.showError(
+        `${this.getUsernameFieldName()} is missing`,
+      );
       return;
     }
     if (
@@ -827,14 +842,18 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
       (this.getRepoName() === undefined || this.getRepoName() === '') &&
       !isSearch
     ) {
-      this.notificationService.showError(`${this.getRepoNameFieldName()} is missing`);
+      this.notificationService.showError(
+        `${this.getRepoNameFieldName()} is missing`,
+      );
       return;
     }
     if (
       this.getTokenFieldName() &&
       (this.token === undefined || this.token === '')
     ) {
-      this.notificationService.showError(`${this.getTokenFieldName()} is missing`);
+      this.notificationService.showError(
+        `${this.getTokenFieldName()} is missing`,
+      );
       return;
     }
     if (
@@ -895,7 +914,7 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
       return;
     }
     this.repoNames = [
-      { label: `searching "${  searchTerm  }"...`, value: searchTerm },
+      { label: `searching "${searchTerm}"...`, value: searchTerm },
     ];
     this.repoSearchSubject.next(searchTerm);
   }
@@ -1004,7 +1023,9 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
           );
           this.getRepoToken(scopes);
         } else {
-          this.notificationService.showError(`Branch lookup failed: ${err.error}`);
+          this.notificationService.showError(
+            `Branch lookup failed: ${err.error}`,
+          );
           this.branchItems = [];
           this.option = undefined;
           this.optionsLoading = false;
@@ -1059,9 +1080,7 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
   }
 
   getDataverseToken(): void {
-    const url =
-      `${this.pluginService.getExternalURL() 
-      }/dataverseuser.xhtml?selectTab=apiTokenTab`;
+    const url = `${this.pluginService.getExternalURL()}/dataverseuser.xhtml?selectTab=apiTokenTab`;
     window.open(url, '_blank');
   }
 
@@ -1158,7 +1177,7 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
       return;
     }
     this.collectionItems = [
-      { label: `searching "${  searchTerm  }"...`, value: searchTerm },
+      { label: `searching "${searchTerm}"...`, value: searchTerm },
     ];
     this.collectionSearchSubject.next(searchTerm);
   }
@@ -1184,9 +1203,9 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
     // Add "Create new dataset" option to the beginning of the list
     const createNewOption: SelectItem<string> = {
       label: '+ Create new dataset',
-      value: 'CREATE_NEW_DATASET'
+      value: 'CREATE_NEW_DATASET',
     };
-    
+
     comp.doiItems = [createNewOption, ...items];
     comp.datasetId = undefined;
   }
@@ -1202,23 +1221,26 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
   }
 
   newDataset() {
-    const datasetId =
-      `${this.collectionId ? this.collectionId! : ''  }:${  new_dataset}`;
-    
+    const datasetId = `${this.collectionId ? this.collectionId! : ''}:${new_dataset}`;
+
     // Create the new dataset option
-    const newDatasetOption: SelectItem<string> = { 
-      label: new_dataset, 
-      value: datasetId 
+    const newDatasetOption: SelectItem<string> = {
+      label: new_dataset,
+      value: datasetId,
     };
-    
+
     // Add it to the dropdown options if not already there
-    const existingIndex = this.doiItems.findIndex(item => item.value === datasetId);
+    const existingIndex = this.doiItems.findIndex(
+      (item) => item.value === datasetId,
+    );
     if (existingIndex === -1) {
       // Remove the "Create new dataset" option temporarily and add the actual new dataset
-      const filteredItems = this.doiItems.filter(item => item.value !== 'CREATE_NEW_DATASET');
+      const filteredItems = this.doiItems.filter(
+        (item) => item.value !== 'CREATE_NEW_DATASET',
+      );
       this.doiItems = [newDatasetOption, ...filteredItems];
     }
-    
+
     this.datasetId = datasetId;
   }
 
@@ -1233,7 +1255,7 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
       return;
     }
     this.doiItems = [
-      { label: `searching "${  searchTerm  }"...`, value: searchTerm },
+      { label: `searching "${searchTerm}"...`, value: searchTerm },
     ];
     this.datasetSearchSubject.next(searchTerm);
   }
@@ -1247,24 +1269,24 @@ export class ConnectComponent implements OnInit, OnDestroy, SubscriptionManager 
         this.dataverseToken,
       ),
     );
-    
+
     // Add "Create new dataset" option to the beginning of results
     const createNewOption: SelectItem<string> = {
       label: '+ Create new dataset',
-      value: 'CREATE_NEW_DATASET'
+      value: 'CREATE_NEW_DATASET',
     };
-    
+
     return [createNewOption, ...items];
   }
 
   onDatasetSelectionChange(event: any) {
     const selectedValue = event.value;
-    
+
     if (selectedValue === 'CREATE_NEW_DATASET') {
       // Handle creation of new dataset
       this.newDataset();
       this.showNewDatasetCreatedMessage = true;
-      
+
       // Hide the message after 3 seconds
       setTimeout(() => {
         this.showNewDatasetCreatedMessage = false;

--- a/src/app/data.service.spec.ts
+++ b/src/app/data.service.spec.ts
@@ -1,5 +1,8 @@
 import { TestBed } from '@angular/core/testing';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { DataService } from './data.service';

--- a/src/app/datafile/datafile.component.spec.ts
+++ b/src/app/datafile/datafile.component.spec.ts
@@ -1,5 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { DatafileComponent } from './datafile.component';
 
@@ -8,12 +11,12 @@ describe('DatafileComponent', () => {
   let fixture: ComponentFixture<DatafileComponent>;
 
   beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        imports: [DatafileComponent],
-        providers: [
-          provideHttpClient(withInterceptorsFromDi()),
-          provideHttpClientTesting(),
-        ],
+    await TestBed.configureTestingModule({
+      imports: [DatafileComponent],
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
     })
       // Shallow render to avoid PrimeNG TreeTable internal provider requirements during unit tests
       .overrideComponent(DatafileComponent, {

--- a/src/app/datafile/datafile.component.ts
+++ b/src/app/datafile/datafile.component.ts
@@ -57,7 +57,7 @@ export class DatafileComponent implements OnInit {
       return '';
     }
     if (this.isInFilter()) {
-      return `${datafile.path ? `${datafile.path  }/` : ''}${datafile.name}`;
+      return `${datafile.path ? `${datafile.path}/` : ''}${datafile.name}`;
     }
     return `${datafile.name}`;
   }
@@ -90,7 +90,9 @@ export class DatafileComponent implements OnInit {
       case Filestatus.Deleted:
         return 'File only in dataset (deleted in repository)';
     }
-    return this.loading() ? 'Loading status...' : 'Click refresh to re-check status';
+    return this.loading()
+      ? 'Loading status...'
+      : 'Click refresh to re-check status';
   }
 
   action(): string {
@@ -117,7 +119,7 @@ export class DatafileComponent implements OnInit {
     ) {
       return '';
     }
-    return `${datafile.path ? `${datafile.path  }/` : ''}${datafile.name}`;
+    return `${datafile.path ? `${datafile.path}/` : ''}${datafile.name}`;
   }
 
   toggleAction(): void {

--- a/src/app/doi.lookup.service.spec.ts
+++ b/src/app/doi.lookup.service.spec.ts
@@ -1,5 +1,8 @@
 import { TestBed } from '@angular/core/testing';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { DvObjectLookupService } from './dvobject.lookup.service';

--- a/src/app/download/download.component.spec.ts
+++ b/src/app/download/download.component.spec.ts
@@ -1,5 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 

--- a/src/app/download/download.component.ts
+++ b/src/app/download/download.component.ts
@@ -35,13 +35,7 @@ import { Tree } from 'primeng/tree';
 import { DownladablefileComponent } from '../downloadablefile/downladablefile.component';
 
 // RxJS
-import {
-  debounceTime,
-  firstValueFrom,
-  map,
-  Observable,
-  Subject,
-} from 'rxjs';
+import { debounceTime, firstValueFrom, map, Observable, Subject } from 'rxjs';
 
 // Constants and types
 import { APP_CONSTANTS } from '../shared/constants';
@@ -64,7 +58,9 @@ import { SubscriptionManager } from '../shared/types';
     Button,
   ],
 })
-export class DownloadComponent implements OnInit, OnDestroy, SubscriptionManager {
+export class DownloadComponent
+  implements OnInit, OnDestroy, SubscriptionManager
+{
   private readonly dvObjectLookupService = inject(DvObjectLookupService);
   private readonly pluginService = inject(PluginService);
   dataService = inject(DataService);
@@ -184,14 +180,14 @@ export class DownloadComponent implements OnInit, OnDestroy, SubscriptionManager
               (err) =>
                 (this.doiItems = [
                   {
-                    label: `search failed: ${  err.message}`,
+                    label: `search failed: ${err.message}`,
                     value: err.message,
                   },
                 ]),
             ),
         error: (err) =>
           (this.doiItems = [
-            { label: `search failed: ${  err.message}`, value: err.message },
+            { label: `search failed: ${err.message}`, value: err.message },
           ]),
       });
     this.repoSearchResultsSubscription =
@@ -203,14 +199,14 @@ export class DownloadComponent implements OnInit, OnDestroy, SubscriptionManager
               (err) =>
                 (this.repoNames = [
                   {
-                    label: `search failed: ${  err.message}`,
+                    label: `search failed: ${err.message}`,
                     value: err.message,
                   },
                 ]),
             ),
         error: (err) =>
           (this.repoNames = [
-            { label: `search failed: ${  err.message}`, value: err.message },
+            { label: `search failed: ${err.message}`, value: err.message },
           ]),
       });
   }
@@ -299,7 +295,7 @@ export class DownloadComponent implements OnInit, OnDestroy, SubscriptionManager
       return;
     }
     this.doiItems = [
-      { label: `searching "${  searchTerm  }"...`, value: searchTerm },
+      { label: `searching "${searchTerm}"...`, value: searchTerm },
     ];
     this.datasetSearchSubject.next(searchTerm);
   }
@@ -332,7 +328,9 @@ export class DownloadComponent implements OnInit, OnDestroy, SubscriptionManager
         },
         error: (err) => {
           subscription.unsubscribe();
-          this.notificationService.showError(`Getting downloadable files failed: ${err.error}`);
+          this.notificationService.showError(
+            `Getting downloadable files failed: ${err.error}`,
+          );
         },
       });
   }
@@ -406,7 +404,9 @@ export class DownloadComponent implements OnInit, OnDestroy, SubscriptionManager
         error: (err) => {
           console.error('something went wrong: ');
           console.error(`${err.error}`);
-          this.notificationService.showError(`Download request failed: ${err.error}`);
+          this.notificationService.showError(
+            `Download request failed: ${err.error}`,
+          );
           httpSubscription.unsubscribe();
         },
       });
@@ -439,7 +439,9 @@ export class DownloadComponent implements OnInit, OnDestroy, SubscriptionManager
       (this.getRepoName() === undefined || this.getRepoName() === '') &&
       !isSearch
     ) {
-      this.notificationService.showError(`${this.getRepoNameFieldName()} is missing`);
+      this.notificationService.showError(
+        `${this.getRepoNameFieldName()} is missing`,
+      );
       return;
     }
     if (
@@ -480,7 +482,7 @@ export class DownloadComponent implements OnInit, OnDestroy, SubscriptionManager
       return;
     }
     this.repoNames = [
-      { label: `searching "${  searchTerm  }"...`, value: searchTerm },
+      { label: `searching "${searchTerm}"...`, value: searchTerm },
     ];
     this.repoSearchSubject.next(searchTerm);
   }
@@ -542,7 +544,9 @@ export class DownloadComponent implements OnInit, OnDestroy, SubscriptionManager
         httpSubscription.unsubscribe();
       },
       error: (err) => {
-        this.notificationService.showError(`Branch lookup failed: ${err.error}`);
+        this.notificationService.showError(
+          `Branch lookup failed: ${err.error}`,
+        );
         this.branchItems = [];
         this.option = undefined;
         this.optionsLoading = false;
@@ -591,14 +595,11 @@ export class DownloadComponent implements OnInit, OnDestroy, SubscriptionManager
       if (url.includes('?')) {
         clId = '&client_id=';
       }
-      url =
-        `${url +
-        clId +
-        encodeURIComponent(tg.oauth_client_id) 
-        }&redirect_uri=${ 
-        this.pluginService.getRedirectUri() 
-        }&response_type=code&state=${ 
-        encodeURIComponent(JSON.stringify(loginState))}`;
+      url = `${
+        url + clId + encodeURIComponent(tg.oauth_client_id)
+      }&redirect_uri=${this.pluginService.getRedirectUri()}&response_type=code&state=${encodeURIComponent(
+        JSON.stringify(loginState),
+      )}`;
       location.href = url;
     } else {
       window.open(url, '_blank');

--- a/src/app/executablefile/executablefile.component.spec.ts
+++ b/src/app/executablefile/executablefile.component.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ExecutablefileComponent } from './executablefile.component';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 describe('ExecutablefileComponent', () => {

--- a/src/app/executablefile/executablefile.component.ts
+++ b/src/app/executablefile/executablefile.component.ts
@@ -85,7 +85,9 @@ export class ExecutablefileComponent implements OnInit {
         },
         error: (err) => {
           subscription.unsubscribe();
-          this.notificationService.showError(`Checking access to queue failed: ${err.error}`);
+          this.notificationService.showError(
+            `Checking access to queue failed: ${err.error}`,
+          );
           this.spinning = false;
           this.queue = undefined;
         },

--- a/src/app/metadata-selector/metadata-selector.component.html
+++ b/src/app/metadata-selector/metadata-selector.component.html
@@ -1,0 +1,57 @@
+<!-- Author: Eryk Kulikowski @ KU Leuven (2023). Apache 2.0 License -->
+<div class="row justify-content-between sticky-menu">
+	<span class="col-auto">
+		<button pButton pRipple type="button" class="p-button-sm p-button-raised p-button-secondary" (click)="back()"><i class="pi pi-angle-double-left"></i>&nbsp;Return</button>
+	</span>
+
+	<span class="col-auto">
+		<button pButton pRipple type="button" [hidden]="!done || !hasAccessToCompute" class="p-button-sm p-button-raised p-button-secondary" (click)="goToCompute()" title="Go to compute">Go to compute&nbsp;<i class="pi pi-angle-double-right"></i></button>
+		<button pButton pRipple type="button" [attr.hidden]="done ? null : ''" class="p-button-sm p-button-raised p-button-secondary" (click)="goToDataset()" title="Go to RDR to see the resulting dataset">Go to dataset&nbsp;<i class="pi pi-angle-double-right"></i></button>
+		<button pButton pRipple type="button" [attr.hidden]="done ? '' : null" class="p-button-sm p-button-raised p-button-secondary" (click)="submit()" title="Initiate selected changes" [attr.disabled]="disabled ? '' : null">Submit&nbsp;<i class="pi pi-angle-double-right"></i></button>
+	</span>
+</div>
+
+<br/>
+
+<h4 style="margin: 3rem; text-align: center;"><i [class]="icon_warning" style="color:red"></i> Make sure not to openly publish sensitive information, copyrighted materials or third-party libraries.</h4>
+<p-dialog header="Submit" position="topright" [modal]="true" [(visible)]="popup">
+	<p class="m-0">Click on "OK" to start the update/transfer. You can close the window and the transfer will continue.</p>
+	<p class="m-0" [hidden]="!sendMails()">You will receive an email to notify you if the update/transfer has been unsuccessful.</p>
+	<br><br>
+	<div style="text-align: right;">
+		<div class="field-checkbox" [hidden]="!sendMails()">
+			<p-checkbox [(ngModel)]="sendEmailOnSuccess" [binary]="true" inputId="sendEmailOnSuccessCB"></p-checkbox>
+			<label for="sendEmailOnSuccesCB">Email me when the update/transfer is completed</label>
+		</div>
+	</div>
+	<ng-template pTemplate="footer">
+		<p-button (click)="continueSubmit()" styleClass="p-button-sm p-button-raised p-button-primary">OK</p-button>
+	</ng-template>
+</p-dialog>
+
+<table class="table">
+	<tbody>
+		<tr [hidden]="!metadata">
+			<th><i [class]="icon_copy"></i> Metadata that will be copied</th>
+		</tr>
+		<tr class="file-list-header" [hidden]="!metadata">
+			<p-treeTable [value]="rootNodeChildren">
+				<ng-template pTemplate="header">
+					<tr>
+						<th style="text-align: left;">Field</th>
+						<th>Value</th>
+						<th class="icon_col" style="text-align: right;">
+							<button pButton pRipple label='' type="button"
+								class="p-button-sm p-button-outlined p-button-secondary" (click)="toggleAction()"><i
+							[class]="action()"></i></button>
+						</th>
+					</tr>
+				</ng-template>
+				<ng-template pTemplate="body" let-rowNode let-rowData="rowData">
+					<tr app-metadatafield [field]="rowData" [rowNodeMap]="rowNodeMap" [rowNode]="rowNode"
+						[style]="rowClass(rowData)">
+					</ng-template>
+				</p-treeTable>
+			</tr>
+	</tbody>
+</table>

--- a/src/app/metadata-selector/metadata-selector.component.html
+++ b/src/app/metadata-selector/metadata-selector.component.html
@@ -4,8 +4,12 @@
 		<button pButton pRipple type="button" class="p-button-sm p-button-raised p-button-secondary" (click)="back()"><i class="pi pi-angle-double-left"></i>&nbsp;Return</button>
 	</span>
 
+    <span class="col-auto">
+      <span class="bulk-label">Select metadata actions</span>
+    </span>
+
 	<span class="col-auto">
-		<button pButton pRipple type="button" [attr.hidden]="done ? '' : null" class="p-button-sm p-button-raised p-button-secondary" (click)="submit()" title="Initiate selected changes" [attr.disabled]="disabled ? '' : null">Submit&nbsp;<i class="pi pi-angle-double-right"></i></button>
+		<button pButton pRipple type="button" class="p-button-sm p-button-raised p-button-primary" (click)="submit()" title="Confirm metadata selection" [attr.disabled]="disabled ? '' : null">Confirm metadata selection&nbsp;<i class="pi pi-angle-double-right"></i></button>
 	</span>
 </div>
 
@@ -20,7 +24,7 @@
 			<p-treeTable [value]="rootNodeChildren">
 				<ng-template pTemplate="header">
 					<tr>
-						<th style="text-align: left;">Field</th>
+						<th style="text-align: left;">Metadata field</th>
 						<th>Value</th>
 						<th class="icon_col" style="text-align: right;">
 							<button pButton pRipple label='' type="button"

--- a/src/app/metadata-selector/metadata-selector.component.html
+++ b/src/app/metadata-selector/metadata-selector.component.html
@@ -5,23 +5,18 @@
 	</span>
 
 	<span class="col-auto">
-		<button pButton pRipple type="button" [hidden]="!done || !hasAccessToCompute" class="p-button-sm p-button-raised p-button-secondary" (click)="goToCompute()" title="Go to compute">Go to compute&nbsp;<i class="pi pi-angle-double-right"></i></button>
-		<button pButton pRipple type="button" [attr.hidden]="done ? null : ''" class="p-button-sm p-button-raised p-button-secondary" (click)="goToDataset()" title="Go to RDR to see the resulting dataset">Go to dataset&nbsp;<i class="pi pi-angle-double-right"></i></button>
 		<button pButton pRipple type="button" [attr.hidden]="done ? '' : null" class="p-button-sm p-button-raised p-button-secondary" (click)="submit()" title="Initiate selected changes" [attr.disabled]="disabled ? '' : null">Submit&nbsp;<i class="pi pi-angle-double-right"></i></button>
 	</span>
 </div>
 
 <br/>
 
-<h4 style="margin: 3rem; text-align: center;"><i [class]="icon_warning" style="color:red"></i> Make sure not to openly publish sensitive information, copyrighted materials or third-party libraries.</h4>
-
-
 <table class="table">
 	<tbody>
-		<tr [hidden]="!metadata">
+		<tr>
 			<th><i [class]="icon_copy"></i> Metadata that will be copied</th>
 		</tr>
-		<tr class="file-list-header" [hidden]="!metadata">
+		<tr class="file-list-header">
 			<p-treeTable [value]="rootNodeChildren">
 				<ng-template pTemplate="header">
 					<tr>

--- a/src/app/metadata-selector/metadata-selector.component.html
+++ b/src/app/metadata-selector/metadata-selector.component.html
@@ -14,20 +14,7 @@
 <br/>
 
 <h4 style="margin: 3rem; text-align: center;"><i [class]="icon_warning" style="color:red"></i> Make sure not to openly publish sensitive information, copyrighted materials or third-party libraries.</h4>
-<p-dialog header="Submit" position="topright" [modal]="true" [(visible)]="popup">
-	<p class="m-0">Click on "OK" to start the update/transfer. You can close the window and the transfer will continue.</p>
-	<p class="m-0" [hidden]="!sendMails()">You will receive an email to notify you if the update/transfer has been unsuccessful.</p>
-	<br><br>
-	<div style="text-align: right;">
-		<div class="field-checkbox" [hidden]="!sendMails()">
-			<p-checkbox [(ngModel)]="sendEmailOnSuccess" [binary]="true" inputId="sendEmailOnSuccessCB"></p-checkbox>
-			<label for="sendEmailOnSuccesCB">Email me when the update/transfer is completed</label>
-		</div>
-	</div>
-	<ng-template pTemplate="footer">
-		<p-button (click)="continueSubmit()" styleClass="p-button-sm p-button-raised p-button-primary">OK</p-button>
-	</ng-template>
-</p-dialog>
+
 
 <table class="table">
 	<tbody>

--- a/src/app/metadata-selector/metadata-selector.component.html
+++ b/src/app/metadata-selector/metadata-selector.component.html
@@ -9,7 +9,7 @@
     </span>
 
 	<span class="col-auto">
-		<button pButton pRipple type="button" class="p-button-sm p-button-raised p-button-primary" (click)="submit()" title="Confirm metadata selection" [attr.disabled]="disabled ? '' : null">Confirm metadata selection&nbsp;<i class="pi pi-angle-double-right"></i></button>
+		<button pButton pRipple type="button" class="p-button-sm p-button-raised p-button-primary" (click)="submit()" title="Confirm metadata selection">Confirm metadata selection&nbsp;<i class="pi pi-angle-double-right"></i></button>
 	</span>
 </div>
 

--- a/src/app/metadata-selector/metadata-selector.component.spec.ts
+++ b/src/app/metadata-selector/metadata-selector.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, flushMicrotasks } from '@angular/core/testing';
 import {
   provideHttpClient,
   withInterceptorsFromDi,
@@ -8,11 +8,77 @@ import { of } from 'rxjs';
 import { Router } from '@angular/router';
 import { MetadataSelectorComponent } from './metadata-selector.component';
 import { DatasetService } from '../dataset.service';
+import { Location } from '@angular/common';
+import { Field, Fieldaction, FieldDictonary, Metadata, MetadataField } from '../models/field';
+import { MetadatafieldComponent } from '../metadatafield/metadatafield.component';
 
 describe('MetadataSelectorComponent', () => {
   let component: MetadataSelectorComponent;
   let fixture: ComponentFixture<MetadataSelectorComponent>;
   let routerNavigateSpy: jasmine.Spy;
+  let locationBackSpy: jasmine.Spy;
+
+  // Build a realistic metadata response with primitive, array, and compound fields
+  const makeMetadata = (): Metadata => {
+    const title: MetadataField = {
+      typeName: 'title',
+      typeClass: 'primitive' as any,
+      multiple: false,
+      value: 'My Dataset',
+    } as any;
+    const keyword: MetadataField = {
+      typeName: 'keyword',
+      typeClass: 'primitive' as any,
+      multiple: true,
+      value: ['science', 'data'],
+    } as any;
+    const author1: FieldDictonary = {
+      authorName: {
+        typeName: 'authorName',
+        typeClass: 'primitive' as any,
+        multiple: false,
+        value: 'Alice',
+      } as any,
+      authorAffiliation: {
+        typeName: 'authorAffiliation',
+        typeClass: 'primitive' as any,
+        multiple: false,
+        value: 'KU Leuven',
+      } as any,
+    };
+    const author2: FieldDictonary = {
+      authorName: {
+        typeName: 'authorName',
+        typeClass: 'primitive' as any,
+        multiple: false,
+        value: 'Bob',
+      } as any,
+      authorAffiliation: {
+        typeName: 'authorAffiliation',
+        typeClass: 'primitive' as any,
+        multiple: false,
+        value: 'UAntwerpen',
+      } as any,
+    };
+    const authorField: MetadataField = {
+      typeName: 'author',
+      typeClass: 'compound' as any,
+      multiple: true,
+      value: [author1, author2],
+    } as any;
+    const metadata: Metadata = {
+      datasetVersion: {
+        metadataBlocks: {
+          citation: {
+            displayName: 'Citation',
+            name: 'citation',
+            fields: [title, keyword, authorField],
+          },
+        },
+      },
+    } as any;
+    return metadata;
+  };
 
   beforeEach(async () => {
     const routerStub = {
@@ -20,19 +86,9 @@ describe('MetadataSelectorComponent', () => {
     } as unknown as Router;
     const datasetStub = {
       newDataset: () => of({ persistentId: 'doi:10.1234/created' }),
-      getMetadata: () =>
-        of({
-          datasetVersion: {
-            metadataBlocks: {
-              citation: {
-                displayName: 'Citation',
-                name: 'citation',
-                fields: [],
-              },
-            },
-          },
-        }),
+      getMetadata: () => of(makeMetadata()),
     } as unknown as DatasetService;
+    const locationStub = { back: jasmine.createSpy('back') } as any as Location;
     await TestBed.configureTestingModule({
       imports: [MetadataSelectorComponent],
       providers: [
@@ -40,6 +96,7 @@ describe('MetadataSelectorComponent', () => {
         provideHttpClientTesting(),
         { provide: Router, useValue: routerStub },
         { provide: DatasetService, useValue: datasetStub },
+        { provide: Location, useValue: locationStub },
       ],
     })
       // Keep template as-is; component uses PrimeNG lightweightly
@@ -48,6 +105,7 @@ describe('MetadataSelectorComponent', () => {
     fixture = TestBed.createComponent(MetadataSelectorComponent);
     component = fixture.componentInstance;
     routerNavigateSpy = TestBed.inject(Router).navigate as jasmine.Spy;
+    locationBackSpy = TestBed.inject(Location).back as jasmine.Spy;
     fixture.detectChanges();
   });
 
@@ -55,9 +113,106 @@ describe('MetadataSelectorComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should navigate to submit after continueSubmit when new dataset is created', async () => {
-    (component as any).pid = 'collectionId:New Dataset';
-    await component.continueSubmit();
-    expect(routerNavigateSpy).toHaveBeenCalledWith(['/submit']);
+  it('should navigate to submit with metadata in state when submitting', async () => {
+    await component.submit();
+    expect(routerNavigateSpy).toHaveBeenCalled();
+    const args = (routerNavigateSpy.calls.mostRecent().args || []) as any[];
+    expect(args[0]).toEqual(['/submit']);
+    expect(args[1]).toBeDefined();
+    expect(args[1].state).toBeDefined();
+  // metadata can be undefined if metadata hasn't loaded yet; we only assert the shape
+  expect(Object.prototype.hasOwnProperty.call(args[1].state, 'metadata')).toBeTrue();
+  });
+
+  it('should load metadata and build tree map', fakeAsync(() => {
+    // ngOnInit already called; wait for async loadData to complete
+    flushMicrotasks();
+    fixture.detectChanges();
+    expect(component.metadata).toBeTruthy();
+    expect(component.root).toBeTruthy();
+    expect(component.rootNodeChildren.length).toBeGreaterThan(0);
+    // Expect names contain title, keyword, author
+    const names = component.rootNodeChildren.map(n => n.data?.name);
+    expect(names).toContain('title');
+    expect(names).toContain('keyword');
+    expect(names).toContain('author');
+    // Row map should have entries for all nodes
+    expect(component.rowNodeMap.size).toBeGreaterThan(3);
+  }));
+
+  it('rowClass should reflect Fieldaction values', () => {
+    const base: Field = { id: 'x', parent: '', name: 'f', action: Fieldaction.Ignore };
+    expect(component.rowClass({ ...base, action: Fieldaction.Ignore })).toBe('');
+    expect(component.rowClass({ ...base, action: Fieldaction.Copy })).toContain('#c3e6cb');
+    expect(component.rowClass({ ...base, action: Fieldaction.Custom })).toContain('#FFFAA0');
+  });
+
+  it('action() and toggleAction() should delegate to MetadatafieldComponent', () => {
+    // prepare a fake root and spy on static methods
+    const root: any = { data: { name: 'root' } };
+    component.root = root;
+    const iconSpy = spyOn(MetadatafieldComponent, 'actionIcon').and.returnValue('icon-x');
+    const toggleSpy = spyOn(MetadatafieldComponent, 'toggleNodeAction');
+    expect(component.action()).toBe('icon-x');
+    component.toggleAction();
+    expect(iconSpy).toHaveBeenCalledWith(root);
+    expect(toggleSpy).toHaveBeenCalledWith(root);
+  });
+
+  it('filteredMetadata should return all fields by default', fakeAsync(() => {
+    flushMicrotasks();
+    fixture.detectChanges();
+    const fm = component.filteredMetadata();
+    expect(fm).toBeTruthy();
+    const fields = fm!.datasetVersion.metadataBlocks.citation.fields;
+    expect(fields.find(f => f.typeName === 'title')!.value).toBe('My Dataset');
+    expect((fields.find(f => f.typeName === 'keyword')!.value as string[]).length).toBe(2);
+    expect((fields.find(f => f.typeName === 'author')!.value as any[]).length).toBe(2);
+  }));
+
+  it('filteredMetadata should prune ignored primitive and nested values', fakeAsync(() => {
+    flushMicrotasks();
+    fixture.detectChanges();
+    // Ignore the title node
+    const titleNode = Array.from(component.rowNodeMap.values()).find(n => n.data?.name === 'title');
+    expect(titleNode).toBeTruthy();
+    if (titleNode && titleNode.data) {
+      titleNode.data.action = Fieldaction.Ignore;
+    }
+    // For compound author, remove one dictionary completely by ignoring all its children
+    const authorNameNodes = Array.from(component.rowNodeMap.values()).filter(n => n.data?.name === 'authorName');
+    expect(authorNameNodes.length).toBeGreaterThan(0);
+    const parentId = authorNameNodes[0].data!.parent!;
+    // Ignore all children under this parent (e.g., authorName and authorAffiliation)
+    Array.from(component.rowNodeMap.values())
+      .filter(n => n.data?.parent === parentId)
+      .forEach(n => (n.data!.action = Fieldaction.Ignore));
+
+    const fm = component.filteredMetadata();
+    expect(fm).toBeTruthy();
+    const fields = fm!.datasetVersion.metadataBlocks.citation.fields;
+    // Title should be removed
+    expect(fields.find(f => f.typeName === 'title')).toBeUndefined();
+    // Author list should be smaller than original
+    const authors = fields.find(f => f.typeName === 'author')!.value as any[];
+    expect(authors.length).toBe(1);
+  }));
+
+  it('submit should navigate with populated metadata once loaded', fakeAsync(() => {
+    flushMicrotasks();
+    fixture.detectChanges();
+    component.submit();
+    const args = (routerNavigateSpy.calls.mostRecent().args || []) as any[];
+    expect(args[0]).toEqual(['/submit']);
+    const state = args[1]?.state;
+    expect(state).toBeDefined();
+    expect(state.metadata).toBeDefined();
+    const fields = state.metadata.datasetVersion.metadataBlocks.citation.fields;
+    expect(fields.length).toBeGreaterThan(0);
+  }));
+
+  it('back should call Location.back()', () => {
+    component.back();
+    expect(locationBackSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/metadata-selector/metadata-selector.component.spec.ts
+++ b/src/app/metadata-selector/metadata-selector.component.spec.ts
@@ -1,0 +1,63 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { Router } from '@angular/router';
+import { MetadataSelectorComponent } from './metadata-selector.component';
+import { DatasetService } from '../dataset.service';
+
+describe('MetadataSelectorComponent', () => {
+  let component: MetadataSelectorComponent;
+  let fixture: ComponentFixture<MetadataSelectorComponent>;
+  let routerNavigateSpy: jasmine.Spy;
+
+  beforeEach(async () => {
+    const routerStub = {
+      navigate: jasmine.createSpy('navigate'),
+    } as unknown as Router;
+    const datasetStub = {
+      newDataset: () => of({ persistentId: 'doi:10.1234/created' }),
+      getMetadata: () =>
+        of({
+          datasetVersion: {
+            metadataBlocks: {
+              citation: {
+                displayName: 'Citation',
+                name: 'citation',
+                fields: [],
+              },
+            },
+          },
+        }),
+    } as unknown as DatasetService;
+    await TestBed.configureTestingModule({
+      imports: [MetadataSelectorComponent],
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        { provide: Router, useValue: routerStub },
+        { provide: DatasetService, useValue: datasetStub },
+      ],
+    })
+      // Keep template as-is; component uses PrimeNG lightweightly
+      .compileComponents();
+
+    fixture = TestBed.createComponent(MetadataSelectorComponent);
+    component = fixture.componentInstance;
+    routerNavigateSpy = TestBed.inject(Router).navigate as jasmine.Spy;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should navigate to submit after continueSubmit when new dataset is created', async () => {
+    (component as any).pid = 'collectionId:New Dataset';
+    await component.continueSubmit();
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['/submit']);
+  });
+});

--- a/src/app/metadata-selector/metadata-selector.component.spec.ts
+++ b/src/app/metadata-selector/metadata-selector.component.spec.ts
@@ -1,4 +1,9 @@
-import { ComponentFixture, TestBed, fakeAsync, flushMicrotasks } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  flushMicrotasks,
+} from '@angular/core/testing';
 import {
   provideHttpClient,
   withInterceptorsFromDi,
@@ -9,7 +14,13 @@ import { Router } from '@angular/router';
 import { MetadataSelectorComponent } from './metadata-selector.component';
 import { DatasetService } from '../dataset.service';
 import { Location } from '@angular/common';
-import { Field, Fieldaction, FieldDictonary, Metadata, MetadataField } from '../models/field';
+import {
+  Field,
+  Fieldaction,
+  FieldDictonary,
+  Metadata,
+  MetadataField,
+} from '../models/field';
 import { MetadatafieldComponent } from '../metadatafield/metadatafield.component';
 
 describe('MetadataSelectorComponent', () => {
@@ -120,8 +131,10 @@ describe('MetadataSelectorComponent', () => {
     expect(args[0]).toEqual(['/submit']);
     expect(args[1]).toBeDefined();
     expect(args[1].state).toBeDefined();
-  // metadata can be undefined if metadata hasn't loaded yet; we only assert the shape
-  expect(Object.prototype.hasOwnProperty.call(args[1].state, 'metadata')).toBeTrue();
+    // metadata can be undefined if metadata hasn't loaded yet; we only assert the shape
+    expect(
+      Object.prototype.hasOwnProperty.call(args[1].state, 'metadata'),
+    ).toBeTrue();
   });
 
   it('should load metadata and build tree map', fakeAsync(() => {
@@ -132,7 +145,7 @@ describe('MetadataSelectorComponent', () => {
     expect(component.root).toBeTruthy();
     expect(component.rootNodeChildren.length).toBeGreaterThan(0);
     // Expect names contain title, keyword, author
-    const names = component.rootNodeChildren.map(n => n.data?.name);
+    const names = component.rootNodeChildren.map((n) => n.data?.name);
     expect(names).toContain('title');
     expect(names).toContain('keyword');
     expect(names).toContain('author');
@@ -141,17 +154,30 @@ describe('MetadataSelectorComponent', () => {
   }));
 
   it('rowClass should reflect Fieldaction values', () => {
-    const base: Field = { id: 'x', parent: '', name: 'f', action: Fieldaction.Ignore };
-    expect(component.rowClass({ ...base, action: Fieldaction.Ignore })).toBe('');
-    expect(component.rowClass({ ...base, action: Fieldaction.Copy })).toContain('#c3e6cb');
-    expect(component.rowClass({ ...base, action: Fieldaction.Custom })).toContain('#FFFAA0');
+    const base: Field = {
+      id: 'x',
+      parent: '',
+      name: 'f',
+      action: Fieldaction.Ignore,
+    };
+    expect(component.rowClass({ ...base, action: Fieldaction.Ignore })).toBe(
+      '',
+    );
+    expect(component.rowClass({ ...base, action: Fieldaction.Copy })).toContain(
+      '#c3e6cb',
+    );
+    expect(
+      component.rowClass({ ...base, action: Fieldaction.Custom }),
+    ).toContain('#FFFAA0');
   });
 
   it('action() and toggleAction() should delegate to MetadatafieldComponent', () => {
     // prepare a fake root and spy on static methods
     const root: any = { data: { name: 'root' } };
     component.root = root;
-    const iconSpy = spyOn(MetadatafieldComponent, 'actionIcon').and.returnValue('icon-x');
+    const iconSpy = spyOn(MetadatafieldComponent, 'actionIcon').and.returnValue(
+      'icon-x',
+    );
     const toggleSpy = spyOn(MetadatafieldComponent, 'toggleNodeAction');
     expect(component.action()).toBe('icon-x');
     component.toggleAction();
@@ -165,36 +191,46 @@ describe('MetadataSelectorComponent', () => {
     const fm = component.filteredMetadata();
     expect(fm).toBeTruthy();
     const fields = fm!.datasetVersion.metadataBlocks.citation.fields;
-    expect(fields.find(f => f.typeName === 'title')!.value).toBe('My Dataset');
-    expect((fields.find(f => f.typeName === 'keyword')!.value as string[]).length).toBe(2);
-    expect((fields.find(f => f.typeName === 'author')!.value as any[]).length).toBe(2);
+    expect(fields.find((f) => f.typeName === 'title')!.value).toBe(
+      'My Dataset',
+    );
+    expect(
+      (fields.find((f) => f.typeName === 'keyword')!.value as string[]).length,
+    ).toBe(2);
+    expect(
+      (fields.find((f) => f.typeName === 'author')!.value as any[]).length,
+    ).toBe(2);
   }));
 
   it('filteredMetadata should prune ignored primitive and nested values', fakeAsync(() => {
     flushMicrotasks();
     fixture.detectChanges();
     // Ignore the title node
-    const titleNode = Array.from(component.rowNodeMap.values()).find(n => n.data?.name === 'title');
+    const titleNode = Array.from(component.rowNodeMap.values()).find(
+      (n) => n.data?.name === 'title',
+    );
     expect(titleNode).toBeTruthy();
     if (titleNode && titleNode.data) {
       titleNode.data.action = Fieldaction.Ignore;
     }
     // For compound author, remove one dictionary completely by ignoring all its children
-    const authorNameNodes = Array.from(component.rowNodeMap.values()).filter(n => n.data?.name === 'authorName');
+    const authorNameNodes = Array.from(component.rowNodeMap.values()).filter(
+      (n) => n.data?.name === 'authorName',
+    );
     expect(authorNameNodes.length).toBeGreaterThan(0);
     const parentId = authorNameNodes[0].data!.parent!;
     // Ignore all children under this parent (e.g., authorName and authorAffiliation)
     Array.from(component.rowNodeMap.values())
-      .filter(n => n.data?.parent === parentId)
-      .forEach(n => (n.data!.action = Fieldaction.Ignore));
+      .filter((n) => n.data?.parent === parentId)
+      .forEach((n) => (n.data!.action = Fieldaction.Ignore));
 
     const fm = component.filteredMetadata();
     expect(fm).toBeTruthy();
     const fields = fm!.datasetVersion.metadataBlocks.citation.fields;
     // Title should be removed
-    expect(fields.find(f => f.typeName === 'title')).toBeUndefined();
+    expect(fields.find((f) => f.typeName === 'title')).toBeUndefined();
     // Author list should be smaller than original
-    const authors = fields.find(f => f.typeName === 'author')!.value as any[];
+    const authors = fields.find((f) => f.typeName === 'author')!.value as any[];
     expect(authors.length).toBe(1);
   }));
 

--- a/src/app/metadata-selector/metadata-selector.component.ts
+++ b/src/app/metadata-selector/metadata-selector.component.ts
@@ -127,7 +127,7 @@ export class MetadataSelectorComponent implements OnInit {
   }
 
   addChild(v: TreeNode<Field>, rowDataMap: Map<string, TreeNode<Field>>): void {
-    if (v.data?.id == '') {
+    if (v.data?.id === '') {
       return;
     }
     const parent = rowDataMap.get(v.data!.parent!)!;

--- a/src/app/metadata-selector/metadata-selector.component.ts
+++ b/src/app/metadata-selector/metadata-selector.component.ts
@@ -31,7 +31,6 @@ import { MetadatafieldComponent } from '../metadatafield/metadatafield.component
 
 // Constants and types
 import { APP_CONSTANTS } from '../shared/constants';
-// SubscriptionManager not needed as we no longer manage subscriptions here
 
 @Component({
   selector: 'app-metadata-selector',

--- a/src/app/metadata-selector/metadata-selector.component.ts
+++ b/src/app/metadata-selector/metadata-selector.component.ts
@@ -285,7 +285,7 @@ export class MetadataSelectorComponent implements OnInit {
       const dict: FieldDictonary = {};
       Object.keys(d).forEach((k) => {
         const f = d[k];
-        if (this.rowNodeMap.get(f.id!)?.data?.action == Fieldaction.Copy) {
+        if (this.rowNodeMap.get(f.id!)?.data?.action === Fieldaction.Copy) {
           const field: MetadataField = {
             expandedvalue: f.expandedvalue,
             multiple: f.multiple,

--- a/src/app/metadata-selector/metadata-selector.component.ts
+++ b/src/app/metadata-selector/metadata-selector.component.ts
@@ -1,24 +1,17 @@
 // Author: Eryk Kulikowski @ KU Leuven (2023). Apache 2.0 License
 
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { Location } from '@angular/common';
-import { Subscription, firstValueFrom } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 
 // Services
-import { DataUpdatesService } from '../data.updates.service';
 import { DataStateService } from '../data.state.service';
-import { PluginService } from '../plugin.service';
-import { UtilsService } from '../utils.service';
 import { CredentialsService } from '../credentials.service';
-import { DataService } from '../data.service';
 import { DatasetService } from '../dataset.service';
-import { NotificationService } from '../shared/notification.service';
 
 // Models
-import { Datafile, Fileaction, Filestatus } from '../models/datafile';
 // import { StoreResult } from '../models/store-result';
-import { CompareResult } from '../models/compare-result';
 import { MetadataRequest } from '../models/metadata-request';
 import {
   Field,
@@ -39,7 +32,7 @@ import { MetadatafieldComponent } from '../metadatafield/metadatafield.component
 
 // Constants and types
 import { APP_CONSTANTS } from '../shared/constants';
-import { SubscriptionManager } from '../shared/types';
+// SubscriptionManager not needed as we no longer manage subscriptions here
 
 @Component({
   selector: 'app-metadata-selector',
@@ -53,40 +46,19 @@ import { SubscriptionManager } from '../shared/types';
     MetadatafieldComponent,
   ],
 })
-export class MetadataSelectorComponent
-  implements OnInit, OnDestroy, SubscriptionManager
-{
+export class MetadataSelectorComponent implements OnInit {
   private readonly dataStateService = inject(DataStateService);
-  private readonly dataUpdatesService = inject(DataUpdatesService);
   private readonly location = inject(Location);
-  private readonly pluginService = inject(PluginService);
   private readonly router = inject(Router);
-  private readonly utils = inject(UtilsService);
-  dataService = inject(DataService);
   private readonly credentialsService = inject(CredentialsService);
   private readonly datasetService = inject(DatasetService);
-  private readonly notificationService = inject(NotificationService);
-
-  // Subscriptions for cleanup
-  private readonly subscriptions = new Set<Subscription>();
 
   // Icon constants
   readonly icon_warning = APP_CONSTANTS.ICONS.WARNING;
   readonly icon_copy = APP_CONSTANTS.ICONS.UPDATE;
-  readonly icon_update = 'pi pi-clone';
-  readonly icon_delete = 'pi pi-trash';
-
-  data: Datafile[] = [];
-  pid = '';
-  datasetUrl = '';
-
-  // local state derived from this.data:
-  created: Datafile[] = [];
-  updated: Datafile[] = [];
-  deleted: Datafile[] = [];
+  // Note: update/delete icons are not used in this component's template
 
   disabled = false;
-  submitted = false;
   done = false;
   // No popup in metadata selector; direct navigation to submit page
   hasAccessToCompute = false;
@@ -99,201 +71,45 @@ export class MetadataSelectorComponent
 
   id = 0;
 
-  constructor() {}
+  constructor() { }
 
   ngOnInit(): void {
+    // Load metadata immediately for rendering in the tree table
     this.loadData();
-    const subscription = this.dataService
-      .checkAccessToQueue(
-        '',
-        this.credentialsService.credentials.dataverse_token,
-        '',
-      )
-      .subscribe({
-        next: (access) => {
-          subscription.unsubscribe();
-          this.hasAccessToCompute = access.access;
-        },
-        error: () => {
-          subscription.unsubscribe();
-        },
-      });
   }
 
-  ngOnDestroy(): void {
-    // Clean up all subscriptions
-    this.subscriptions.forEach((sub) => sub.unsubscribe());
-    this.subscriptions.clear();
-  }
-
-  getDataSubscription(): void {
-    const dataSubscription = this.dataUpdatesService
-      .updateData(this.data, this.pid)
-      .subscribe({
-        next: async (res: CompareResult) => {
-          dataSubscription?.unsubscribe();
-          if (res.data !== undefined) {
-            this.setData(res.data);
-          }
-          if (!this.hasUnfinishedDataFiles()) {
-            this.done = true;
-          } else {
-            await this.utils.sleep(1000);
-            this.getDataSubscription();
-          }
-        },
-        error: (err) => {
-          dataSubscription?.unsubscribe();
-          this.notificationService.showError(
-            `Getting status of data failed: ${err.error}`,
-          );
-          this.router.navigate(['/connect']);
-        },
-      });
-  }
-
-  hasUnfinishedDataFiles(): boolean {
-    return (
-      this.created.some((d) => d.status !== Filestatus.Equal) ||
-      this.updated.some((d) => d.status !== Filestatus.Equal) ||
-      this.deleted.some((d) => d.status !== Filestatus.New)
+  async loadData() {
+    const credentials = this.credentialsService.credentials;
+    const req: MetadataRequest = {
+      pluginId: credentials.pluginId,
+      plugin: credentials.plugin,
+      repoName: credentials.repo_name,
+      url: credentials.url,
+      option: credentials.option,
+      user: credentials.user,
+      token: credentials.token,
+      dvToken: credentials.dataverse_token,
+      compareResult: this.dataStateService.getCurrentValue(),
+    };
+    this.metadata = await firstValueFrom(
+      this.datasetService.getMetadata(req),
     );
-  }
-
-  loadData(): void {
-    const value = this.dataStateService.getCurrentValue();
-    this.pid = value && value.id ? value.id : '';
-    const data = value?.data;
-    if (data) {
-      this.setData(data);
+    const rowDataMap = this.mapFields(this.metadata);
+    rowDataMap.forEach((v) => this.addChild(v, rowDataMap));
+    this.root = rowDataMap.get('');
+    this.rowNodeMap = rowDataMap;
+    if (this.root?.children) {
+      this.rootNodeChildren = this.root.children;
     }
-  }
-
-  async setData(data: Datafile[]) {
-    this.data = data;
-    this.created = this.toCreate();
-    this.updated = this.toUpdate();
-    this.deleted = this.toDelete();
-    this.data = [...this.created, ...this.updated, ...this.deleted];
-    if (this.pid.endsWith(':New Dataset')) {
-      const credentials = this.credentialsService.credentials;
-      const req: MetadataRequest = {
-        pluginId: credentials.pluginId,
-        plugin: credentials.plugin,
-        repoName: credentials.repo_name,
-        url: credentials.url,
-        option: credentials.option,
-        user: credentials.user,
-        token: credentials.token,
-        dvToken: credentials.dataverse_token,
-        compareResult: this.dataStateService.getCurrentValue(),
-      };
-      this.metadata = await firstValueFrom(
-        this.datasetService.getMetadata(req),
-      );
-      const rowDataMap = this.mapFields(this.metadata);
-      rowDataMap.forEach((v) => this.addChild(v, rowDataMap));
-      this.root = rowDataMap.get('');
-      this.rowNodeMap = rowDataMap;
-      if (this.root?.children) {
-        this.rootNodeChildren = this.root.children;
-      }
-    }
-  }
-
-  toCreate(): Datafile[] {
-    const result: Datafile[] = [];
-    this.data.forEach((datafile) => {
-      if (datafile.action === Fileaction.Copy) {
-        result.push(datafile);
-      }
-    });
-    return result;
-  }
-
-  toUpdate(): Datafile[] {
-    const result: Datafile[] = [];
-    this.data.forEach((datafile) => {
-      if (datafile.action === Fileaction.Update) {
-        result.push(datafile);
-      }
-    });
-    return result;
-  }
-
-  toDelete(): Datafile[] {
-    const result: Datafile[] = [];
-    this.data.forEach((datafile) => {
-      if (datafile.action === Fileaction.Delete) {
-        if (
-          datafile.attributes?.remoteHashType === undefined ||
-          datafile.attributes?.remoteHashType === ''
-        ) {
-          // file from unknown origin, by setting the hash type to not empty value we can detect in comparison that the file got deleted
-          datafile.attributes!.remoteHashType = 'unknown';
-          datafile.attributes!.remoteHash = 'unknown';
-        }
-        result.push(datafile);
-      }
-    });
-    return result;
   }
 
   submit() {
-    // In metadata selector, clicking Submit should proceed immediately to the submit page
-    this.continueSubmit();
-  }
-
-  async continueSubmit() {
-    this.disabled = true;
-
-    // If this is a new dataset flow, first create the dataset based on selected metadata
-    if (this.pid.endsWith(':New Dataset')) {
-      const ids = this.pid.split(':');
-      const ok = await this.newDataset(ids[0]);
-      if (!ok) {
-        this.disabled = false;
-        return;
-      }
-    }
-
-    // After metadata selection (and dataset creation when needed), proceed to the Submit page for files
-    this.router.navigate(['/submit']);
+    const metadata = this.filteredMetadata();
+    this.router.navigate(['/submit'], { state: { metadata } });
   }
 
   back(): void {
     this.location.back();
-  }
-
-  goToDataset() {
-    window.open(this.datasetUrl, '_blank');
-  }
-
-  goToCompute() {
-    this.router.navigate(['/compute'], { queryParams: { pid: this.pid } });
-  }
-
-  sendMails(): boolean {
-    return this.pluginService.sendMails();
-  }
-
-  async newDataset(collectionId: string): Promise<boolean> {
-    const metadata = this.filteredMetadata();
-    const data = await firstValueFrom(
-      this.datasetService.newDataset(
-        collectionId,
-        this.credentialsService.credentials.dataverse_token,
-        metadata,
-      ),
-    );
-    if (data.persistentId !== undefined && data.persistentId !== '') {
-      this.pid = data.persistentId;
-      this.credentialsService.credentials.dataset_id = data.persistentId;
-      return true;
-    } else {
-      this.notificationService.showError('Creating new dataset failed');
-      return false;
-    }
   }
 
   action(): string {

--- a/src/app/metadata-selector/metadata-selector.component.ts
+++ b/src/app/metadata-selector/metadata-selector.component.ts
@@ -71,7 +71,7 @@ export class MetadataSelectorComponent implements OnInit {
 
   id = 0;
 
-  constructor() { }
+  constructor() {}
 
   ngOnInit(): void {
     // Load metadata immediately for rendering in the tree table
@@ -91,9 +91,7 @@ export class MetadataSelectorComponent implements OnInit {
       dvToken: credentials.dataverse_token,
       compareResult: this.dataStateService.getCurrentValue(),
     };
-    this.metadata = await firstValueFrom(
-      this.datasetService.getMetadata(req),
-    );
+    this.metadata = await firstValueFrom(this.datasetService.getMetadata(req));
     const rowDataMap = this.mapFields(this.metadata);
     rowDataMap.forEach((v) => this.addChild(v, rowDataMap));
     this.root = rowDataMap.get('');

--- a/src/app/metadata-selector/metadata-selector.component.ts
+++ b/src/app/metadata-selector/metadata-selector.component.ts
@@ -237,7 +237,7 @@ export class MetadataSelectorComponent implements OnInit {
     }
     let res: MetadataField[] = [];
     this.metadata.datasetVersion.metadataBlocks.citation.fields.forEach((f) => {
-      if (this.rowNodeMap.get(f.id!)?.data?.action == Fieldaction.Copy) {
+      if (this.rowNodeMap.get(f.id!)?.data?.action === Fieldaction.Copy) {
         const field: MetadataField = {
           expandedvalue: f.expandedvalue,
           multiple: f.multiple,

--- a/src/app/metadata-selector/metadata-selector.component.ts
+++ b/src/app/metadata-selector/metadata-selector.component.ts
@@ -59,7 +59,6 @@ export class MetadataSelectorComponent implements OnInit {
   // Note: update/delete icons are not used in this component's template
 
   disabled = false;
-  done = false;
   // No popup in metadata selector; direct navigation to submit page
   hasAccessToCompute = false;
 

--- a/src/app/metadata-selector/metadata-selector.component.ts
+++ b/src/app/metadata-selector/metadata-selector.component.ts
@@ -30,11 +30,8 @@ import {
 
 // PrimeNG
 import { TreeNode, PrimeTemplate } from 'primeng/api';
-import { ButtonDirective, Button } from 'primeng/button';
+import { ButtonDirective } from 'primeng/button';
 import { Ripple } from 'primeng/ripple';
-import { Dialog } from 'primeng/dialog';
-import { Checkbox } from 'primeng/checkbox';
-import { FormsModule } from '@angular/forms';
 import { TreeTableModule } from 'primeng/treetable';
 
 // Components
@@ -50,11 +47,7 @@ import { SubscriptionManager } from '../shared/types';
   styleUrls: ['./metadata-selector.component.scss'],
   imports: [
     ButtonDirective,
-    Button,
     Ripple,
-    Dialog,
-    Checkbox,
-    FormsModule,
     PrimeTemplate,
     TreeTableModule,
     MetadatafieldComponent,
@@ -95,8 +88,7 @@ export class MetadataSelectorComponent
   disabled = false;
   submitted = false;
   done = false;
-  sendEmailOnSuccess = false;
-  popup = false;
+  // No popup in metadata selector; direct navigation to submit page
   hasAccessToCompute = false;
 
   metadata?: Metadata;
@@ -248,15 +240,11 @@ export class MetadataSelectorComponent
   }
 
   submit() {
-    if (this.credentialsService.credentials.plugin === 'globus') {
-      this.continueSubmit();
-    } else {
-      this.popup = true;
-    }
+    // In metadata selector, clicking Submit should proceed immediately to the submit page
+    this.continueSubmit();
   }
 
   async continueSubmit() {
-    this.popup = false;
     this.disabled = true;
 
     // If this is a new dataset flow, first create the dataset based on selected metadata

--- a/src/app/metadata-selector/metadata-selector.component.ts
+++ b/src/app/metadata-selector/metadata-selector.component.ts
@@ -54,13 +54,7 @@ export class MetadataSelectorComponent implements OnInit {
   private readonly datasetService = inject(DatasetService);
 
   // Icon constants
-  readonly icon_warning = APP_CONSTANTS.ICONS.WARNING;
   readonly icon_copy = APP_CONSTANTS.ICONS.UPDATE;
-  // Note: update/delete icons are not used in this component's template
-
-  disabled = false;
-  // No popup in metadata selector; direct navigation to submit page
-  hasAccessToCompute = false;
 
   metadata?: Metadata;
 

--- a/src/app/metadata-selector/metadata-selector.component.ts
+++ b/src/app/metadata-selector/metadata-selector.component.ts
@@ -11,7 +11,6 @@ import { CredentialsService } from '../credentials.service';
 import { DatasetService } from '../dataset.service';
 
 // Models
-// import { StoreResult } from '../models/store-result';
 import { MetadataRequest } from '../models/metadata-request';
 import {
   Field,

--- a/src/app/metadata-selector/metadata-selector.component.ts
+++ b/src/app/metadata-selector/metadata-selector.component.ts
@@ -1,0 +1,529 @@
+// Author: Eryk Kulikowski @ KU Leuven (2023). Apache 2.0 License
+
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { Location } from '@angular/common';
+import { Subscription, firstValueFrom } from 'rxjs';
+
+// Services
+import { DataUpdatesService } from '../data.updates.service';
+import { DataStateService } from '../data.state.service';
+import { PluginService } from '../plugin.service';
+import { UtilsService } from '../utils.service';
+import { CredentialsService } from '../credentials.service';
+import { DataService } from '../data.service';
+import { DatasetService } from '../dataset.service';
+import { NotificationService } from '../shared/notification.service';
+
+// Models
+import { Datafile, Fileaction, Filestatus } from '../models/datafile';
+// import { StoreResult } from '../models/store-result';
+import { CompareResult } from '../models/compare-result';
+import { MetadataRequest } from '../models/metadata-request';
+import {
+  Field,
+  Fieldaction,
+  FieldDictonary,
+  Metadata,
+  MetadataField,
+} from '../models/field';
+
+// PrimeNG
+import { TreeNode, PrimeTemplate } from 'primeng/api';
+import { ButtonDirective, Button } from 'primeng/button';
+import { Ripple } from 'primeng/ripple';
+import { Dialog } from 'primeng/dialog';
+import { Checkbox } from 'primeng/checkbox';
+import { FormsModule } from '@angular/forms';
+import { TreeTableModule } from 'primeng/treetable';
+
+// Components
+import { MetadatafieldComponent } from '../metadatafield/metadatafield.component';
+
+// Constants and types
+import { APP_CONSTANTS } from '../shared/constants';
+import { SubscriptionManager } from '../shared/types';
+
+@Component({
+  selector: 'app-metadata-selector',
+  templateUrl: './metadata-selector.component.html',
+  styleUrls: ['./metadata-selector.component.scss'],
+  imports: [
+    ButtonDirective,
+    Button,
+    Ripple,
+    Dialog,
+    Checkbox,
+    FormsModule,
+    PrimeTemplate,
+    TreeTableModule,
+    MetadatafieldComponent,
+  ],
+})
+export class MetadataSelectorComponent
+  implements OnInit, OnDestroy, SubscriptionManager
+{
+  private readonly dataStateService = inject(DataStateService);
+  private readonly dataUpdatesService = inject(DataUpdatesService);
+  private readonly location = inject(Location);
+  private readonly pluginService = inject(PluginService);
+  private readonly router = inject(Router);
+  private readonly utils = inject(UtilsService);
+  dataService = inject(DataService);
+  private readonly credentialsService = inject(CredentialsService);
+  private readonly datasetService = inject(DatasetService);
+  private readonly notificationService = inject(NotificationService);
+
+  // Subscriptions for cleanup
+  private readonly subscriptions = new Set<Subscription>();
+
+  // Icon constants
+  readonly icon_warning = APP_CONSTANTS.ICONS.WARNING;
+  readonly icon_copy = APP_CONSTANTS.ICONS.UPDATE;
+  readonly icon_update = 'pi pi-clone';
+  readonly icon_delete = 'pi pi-trash';
+
+  data: Datafile[] = [];
+  pid = '';
+  datasetUrl = '';
+
+  // local state derived from this.data:
+  created: Datafile[] = [];
+  updated: Datafile[] = [];
+  deleted: Datafile[] = [];
+
+  disabled = false;
+  submitted = false;
+  done = false;
+  sendEmailOnSuccess = false;
+  popup = false;
+  hasAccessToCompute = false;
+
+  metadata?: Metadata;
+
+  root?: TreeNode<Field>;
+  rootNodeChildren: TreeNode<Field>[] = [];
+  rowNodeMap: Map<string, TreeNode<Field>> = new Map<string, TreeNode<Field>>();
+
+  id = 0;
+
+  constructor() {}
+
+  ngOnInit(): void {
+    this.loadData();
+    const subscription = this.dataService
+      .checkAccessToQueue(
+        '',
+        this.credentialsService.credentials.dataverse_token,
+        '',
+      )
+      .subscribe({
+        next: (access) => {
+          subscription.unsubscribe();
+          this.hasAccessToCompute = access.access;
+        },
+        error: () => {
+          subscription.unsubscribe();
+        },
+      });
+  }
+
+  ngOnDestroy(): void {
+    // Clean up all subscriptions
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
+    this.subscriptions.clear();
+  }
+
+  getDataSubscription(): void {
+    const dataSubscription = this.dataUpdatesService
+      .updateData(this.data, this.pid)
+      .subscribe({
+        next: async (res: CompareResult) => {
+          dataSubscription?.unsubscribe();
+          if (res.data !== undefined) {
+            this.setData(res.data);
+          }
+          if (!this.hasUnfinishedDataFiles()) {
+            this.done = true;
+          } else {
+            await this.utils.sleep(1000);
+            this.getDataSubscription();
+          }
+        },
+        error: (err) => {
+          dataSubscription?.unsubscribe();
+          this.notificationService.showError(
+            `Getting status of data failed: ${err.error}`,
+          );
+          this.router.navigate(['/connect']);
+        },
+      });
+  }
+
+  hasUnfinishedDataFiles(): boolean {
+    return (
+      this.created.some((d) => d.status !== Filestatus.Equal) ||
+      this.updated.some((d) => d.status !== Filestatus.Equal) ||
+      this.deleted.some((d) => d.status !== Filestatus.New)
+    );
+  }
+
+  loadData(): void {
+    const value = this.dataStateService.getCurrentValue();
+    this.pid = value && value.id ? value.id : '';
+    const data = value?.data;
+    if (data) {
+      this.setData(data);
+    }
+  }
+
+  async setData(data: Datafile[]) {
+    this.data = data;
+    this.created = this.toCreate();
+    this.updated = this.toUpdate();
+    this.deleted = this.toDelete();
+    this.data = [...this.created, ...this.updated, ...this.deleted];
+    if (this.pid.endsWith(':New Dataset')) {
+      const credentials = this.credentialsService.credentials;
+      const req: MetadataRequest = {
+        pluginId: credentials.pluginId,
+        plugin: credentials.plugin,
+        repoName: credentials.repo_name,
+        url: credentials.url,
+        option: credentials.option,
+        user: credentials.user,
+        token: credentials.token,
+        dvToken: credentials.dataverse_token,
+        compareResult: this.dataStateService.getCurrentValue(),
+      };
+      this.metadata = await firstValueFrom(
+        this.datasetService.getMetadata(req),
+      );
+      const rowDataMap = this.mapFields(this.metadata);
+      rowDataMap.forEach((v) => this.addChild(v, rowDataMap));
+      this.root = rowDataMap.get('');
+      this.rowNodeMap = rowDataMap;
+      if (this.root?.children) {
+        this.rootNodeChildren = this.root.children;
+      }
+    }
+  }
+
+  toCreate(): Datafile[] {
+    const result: Datafile[] = [];
+    this.data.forEach((datafile) => {
+      if (datafile.action === Fileaction.Copy) {
+        result.push(datafile);
+      }
+    });
+    return result;
+  }
+
+  toUpdate(): Datafile[] {
+    const result: Datafile[] = [];
+    this.data.forEach((datafile) => {
+      if (datafile.action === Fileaction.Update) {
+        result.push(datafile);
+      }
+    });
+    return result;
+  }
+
+  toDelete(): Datafile[] {
+    const result: Datafile[] = [];
+    this.data.forEach((datafile) => {
+      if (datafile.action === Fileaction.Delete) {
+        if (
+          datafile.attributes?.remoteHashType === undefined ||
+          datafile.attributes?.remoteHashType === ''
+        ) {
+          // file from unknown origin, by setting the hash type to not empty value we can detect in comparison that the file got deleted
+          datafile.attributes!.remoteHashType = 'unknown';
+          datafile.attributes!.remoteHash = 'unknown';
+        }
+        result.push(datafile);
+      }
+    });
+    return result;
+  }
+
+  submit() {
+    if (this.credentialsService.credentials.plugin === 'globus') {
+      this.continueSubmit();
+    } else {
+      this.popup = true;
+    }
+  }
+
+  async continueSubmit() {
+    this.popup = false;
+    this.disabled = true;
+
+    // If this is a new dataset flow, first create the dataset based on selected metadata
+    if (this.pid.endsWith(':New Dataset')) {
+      const ids = this.pid.split(':');
+      const ok = await this.newDataset(ids[0]);
+      if (!ok) {
+        this.disabled = false;
+        return;
+      }
+    }
+
+    // After metadata selection (and dataset creation when needed), proceed to the Submit page for files
+    this.router.navigate(['/submit']);
+  }
+
+  back(): void {
+    this.location.back();
+  }
+
+  goToDataset() {
+    window.open(this.datasetUrl, '_blank');
+  }
+
+  goToCompute() {
+    this.router.navigate(['/compute'], { queryParams: { pid: this.pid } });
+  }
+
+  sendMails(): boolean {
+    return this.pluginService.sendMails();
+  }
+
+  async newDataset(collectionId: string): Promise<boolean> {
+    const metadata = this.filteredMetadata();
+    const data = await firstValueFrom(
+      this.datasetService.newDataset(
+        collectionId,
+        this.credentialsService.credentials.dataverse_token,
+        metadata,
+      ),
+    );
+    if (data.persistentId !== undefined && data.persistentId !== '') {
+      this.pid = data.persistentId;
+      this.credentialsService.credentials.dataset_id = data.persistentId;
+      return true;
+    } else {
+      this.notificationService.showError('Creating new dataset failed');
+      return false;
+    }
+  }
+
+  action(): string {
+    if (this.root) {
+      return MetadatafieldComponent.actionIcon(this.root);
+    }
+    return MetadatafieldComponent.icon_ignore;
+  }
+
+  toggleAction(): void {
+    if (this.root) {
+      MetadatafieldComponent.toggleNodeAction(this.root);
+    }
+  }
+
+  rowClass(field: Field): string {
+    switch (field.action) {
+      case Fieldaction.Ignore:
+        return '';
+      case Fieldaction.Copy:
+        return 'background-color: #c3e6cb; color: black';
+      case Fieldaction.Custom:
+        return 'background-color: #FFFAA0; color: black';
+    }
+    return '';
+  }
+
+  addChild(v: TreeNode<Field>, rowDataMap: Map<string, TreeNode<Field>>): void {
+    if (v.data?.id == '') {
+      return;
+    }
+    const parent = rowDataMap.get(v.data!.parent!)!;
+    const children = parent.children ? parent.children : [];
+    parent.children = children.concat(v);
+  }
+
+  mapFields(metadata: Metadata): Map<string, TreeNode<Field>> {
+    const rootData: Field = {
+      id: '',
+      parent: '',
+      name: '',
+      action: Fieldaction.Copy,
+    };
+
+    const rowDataMap: Map<string, TreeNode<Field>> = new Map<
+      string,
+      TreeNode<Field>
+    >();
+    rowDataMap.set('', {
+      data: rootData,
+    });
+
+    metadata.datasetVersion.metadataBlocks.citation.fields.forEach((d) => {
+      this.addToDataMap(d, '', rowDataMap);
+    });
+    return rowDataMap;
+  }
+
+  private addToDataMap(
+    d: MetadataField,
+    parent: string,
+    rowDataMap: Map<string, TreeNode<Field>>,
+  ) {
+    if (
+      d.value &&
+      Array.isArray(d.value) &&
+      d.value.length > 0 &&
+      typeof d.value[0] === 'string'
+    ) {
+      let content = d.value[0];
+      for (let i = 1; i < d.value.length; i++) {
+        content = `${content}, ${d.value[i]}`;
+      }
+      const id = `${this.id++}`;
+      d.id = id;
+      const data: Field = {
+        id: id,
+        parent: parent,
+        name: d.typeName,
+        action: Fieldaction.Copy,
+        leafValue: content,
+        field: d,
+      };
+      rowDataMap.set(id, {
+        data: data,
+      });
+    } else if (d.value && typeof d.value !== 'string') {
+      (d.value as FieldDictonary[]).forEach((v) => {
+        const id = `${this.id++}`;
+        const data: Field = {
+          id: id,
+          parent: parent,
+          name: d.typeName,
+          action: Fieldaction.Copy,
+          field: v,
+        };
+        rowDataMap.set(id, {
+          data: data,
+        });
+        this.mapChildField(id, v, rowDataMap);
+      });
+    } else {
+      const id = `${this.id++}`;
+      d.id = id;
+      const data: Field = {
+        id: id,
+        parent: parent,
+        name: d.typeName,
+        action: Fieldaction.Copy,
+        leafValue: d.value,
+        field: d,
+      };
+      rowDataMap.set(id, {
+        data: data,
+      });
+    }
+  }
+
+  mapChildField(
+    parent: string,
+    fieldDictonary: FieldDictonary,
+    rowDataMap: Map<string, TreeNode<Field>>,
+  ) {
+    Object.values(fieldDictonary).forEach((d) => {
+      this.addToDataMap(d, parent, rowDataMap);
+    });
+  }
+
+  filteredMetadata(): Metadata | undefined {
+    if (
+      !this.metadata ||
+      !this.rootNodeChildren ||
+      this.rootNodeChildren.length === 0
+    ) {
+      return undefined;
+    }
+    let res: MetadataField[] = [];
+    this.metadata.datasetVersion.metadataBlocks.citation.fields.forEach((f) => {
+      if (this.rowNodeMap.get(f.id!)?.data?.action == Fieldaction.Copy) {
+        const field: MetadataField = {
+          expandedvalue: f.expandedvalue,
+          multiple: f.multiple,
+          typeClass: f.typeClass,
+          typeName: f.typeName,
+          value: f.value,
+        };
+        res = res.concat(field);
+      } else if (
+        f.value &&
+        Array.isArray(f.value) &&
+        f.value.length > 0 &&
+        typeof f.value[0] !== 'string'
+      ) {
+        const dicts = this.customValue(f.value as FieldDictonary[]);
+        if (dicts.length > 0) {
+          const field: MetadataField = {
+            expandedvalue: f.expandedvalue,
+            multiple: f.multiple,
+            typeClass: f.typeClass,
+            typeName: f.typeName,
+            value: dicts,
+          };
+          res = res.concat(field);
+        }
+      }
+    });
+    return {
+      datasetVersion: {
+        metadataBlocks: {
+          citation: {
+            displayName:
+              this.metadata.datasetVersion.metadataBlocks.citation.displayName,
+            fields: res,
+            name: this.metadata.datasetVersion.metadataBlocks.citation.name,
+          },
+        },
+      },
+    };
+  }
+
+  customValue(metadataFields: FieldDictonary[]): FieldDictonary[] {
+    let res: FieldDictonary[] = [];
+    metadataFields.forEach((d) => {
+      const dict: FieldDictonary = {};
+      Object.keys(d).forEach((k) => {
+        const f = d[k];
+        if (this.rowNodeMap.get(f.id!)?.data?.action == Fieldaction.Copy) {
+          const field: MetadataField = {
+            expandedvalue: f.expandedvalue,
+            multiple: f.multiple,
+            typeClass: f.typeClass,
+            typeName: f.typeName,
+            value: f.value,
+          };
+          dict[k] = field;
+        } else if (
+          f.value &&
+          Array.isArray(f.value) &&
+          f.value.length > 0 &&
+          typeof f.value[0] !== 'string'
+        ) {
+          const dicts = this.customValue(f.value as FieldDictonary[]);
+          if (dicts.length > 0) {
+            const field: MetadataField = {
+              expandedvalue: f.expandedvalue,
+              multiple: f.multiple,
+              typeClass: f.typeClass,
+              typeName: f.typeName,
+              value: this.customValue(f.value as FieldDictonary[]),
+            };
+            dict[k] = field;
+          }
+        }
+      });
+      if (Object.keys(dict).length > 0) {
+        res = res.concat(dict);
+      }
+    });
+    return res;
+  }
+}

--- a/src/app/oauth.service.spec.ts
+++ b/src/app/oauth.service.spec.ts
@@ -1,5 +1,8 @@
 import { TestBed } from '@angular/core/testing';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { OauthService } from './oauth.service';

--- a/src/app/plugin.service.spec.ts
+++ b/src/app/plugin.service.spec.ts
@@ -1,5 +1,8 @@
 import { TestBed } from '@angular/core/testing';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { PluginService } from './plugin.service';

--- a/src/app/repo.lookup.service.spec.ts
+++ b/src/app/repo.lookup.service.spec.ts
@@ -1,5 +1,8 @@
 import { TestBed } from '@angular/core/testing';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { RepoLookupService } from './repo.lookup.service';

--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -21,7 +21,7 @@ export const APP_CONSTANTS = {
     SUBMIT: 'pi pi-save',
     COMPARE: 'pi pi-flag',
     ACTION: 'pi pi-bolt',
-  WARNING: 'pi pi-stop',
+    WARNING: 'pi pi-stop',
     FILTER: 'pi pi-filter',
     PLAY: 'pi pi-play',
     NEW_FILE: 'pi pi-plus-circle',
@@ -41,12 +41,12 @@ export const APP_CONSTANTS = {
   // File action styles
   FILE_ACTION_STYLES: {
     IGNORE: '',
-  COPY: 'background-color: #c3e6cb; color: black',
-  UPDATE: 'background-color: #b8daff; color: black',
-  DELETE: 'background-color: #f5c6cb; color: black',
-  // Non-uniform selection: grey/light blue tint
-  CUSTOM: 'background-color: #e7f1ff; color: #495057',
-  }
+    COPY: 'background-color: #c3e6cb; color: black',
+    UPDATE: 'background-color: #b8daff; color: black',
+    DELETE: 'background-color: #f5c6cb; color: black',
+    // Non-uniform selection: grey/light blue tint
+    CUSTOM: 'background-color: #e7f1ff; color: #495057',
+  },
 } as const;
 
 /**

--- a/src/app/shared/notification.service.ts
+++ b/src/app/shared/notification.service.ts
@@ -4,10 +4,9 @@ import { Injectable } from '@angular/core';
  * Service for handling errors and user notifications
  */
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class NotificationService {
-  
   /**
    * Show an error message to the user
    * TODO: Replace with proper notification system (e.g., toast, snackbar)
@@ -52,7 +51,7 @@ export class NotificationService {
    */
   handleHttpError(error: unknown, context?: string): void {
     let message = 'An unexpected error occurred';
-    
+
     if (error && typeof error === 'object' && 'error' in error) {
       message = String(error.error);
     } else if (error && typeof error === 'object' && 'message' in error) {

--- a/src/app/shared/types.ts
+++ b/src/app/shared/types.ts
@@ -31,7 +31,7 @@ export enum LoadingState {
   IDLE = 'idle',
   LOADING = 'loading',
   SUCCESS = 'success',
-  ERROR = 'error'
+  ERROR = 'error',
 }
 
 /**

--- a/src/app/submit/submit.component.html
+++ b/src/app/submit/submit.component.html
@@ -31,28 +31,7 @@
 
 <table class="table">
   <tbody>
-    <tr [hidden]="!metadata">
-      <th><i [class]="icon_copy"></i> Metadata that will be copied</th>
-    </tr>
-    <tr class="file-list-header" [hidden]="!metadata">
-      <p-treeTable [value]="rootNodeChildren">
-        <ng-template pTemplate="header">
-          <tr>
-            <th style="text-align: left;">Field</th>
-            <th>Value</th>
-            <th class="icon_col" style="text-align: right;">
-              <button pButton pRipple label='' type="button"
-                class="p-button-sm p-button-outlined p-button-secondary" (click)="toggleAction()"><i
-              [class]="action()"></i></button>
-            </th>
-          </tr>
-        </ng-template>
-        <ng-template pTemplate="body" let-rowNode let-rowData="rowData">
-          <tr app-metadatafield [field]="rowData" [rowNodeMap]="rowNodeMap" [rowNode]="rowNode"
-            [style]="rowClass(rowData)">
-          </ng-template>
-        </p-treeTable>
-      </tr>
+    
       <tr class="file-list-header">
         <th><i [class]="icon_copy"></i> Files that will be created</th>
       </tr>

--- a/src/app/submit/submit.component.html
+++ b/src/app/submit/submit.component.html
@@ -31,7 +31,28 @@
 
 <table class="table">
   <tbody>
-    
+    <tr [hidden]="!metadata">
+      <th><i [class]="icon_copy"></i> Metadata that will be copied</th>
+    </tr>
+    <tr class="file-list-header" [hidden]="!metadata">
+      <p-treeTable [value]="rootNodeChildren">
+        <ng-template pTemplate="header">
+          <tr>
+            <th style="text-align: left;">Field</th>
+            <th>Value</th>
+            <th class="icon_col" style="text-align: right;">
+              <button pButton pRipple label='' type="button"
+                class="p-button-sm p-button-outlined p-button-secondary" (click)="toggleAction()"><i
+              [class]="action()"></i></button>
+            </th>
+          </tr>
+        </ng-template>
+        <ng-template pTemplate="body" let-rowNode let-rowData="rowData">
+          <tr app-metadatafield [field]="rowData" [rowNodeMap]="rowNodeMap" [rowNode]="rowNode"
+            [style]="rowClass(rowData)">
+          </ng-template>
+        </p-treeTable>
+      </tr>
       <tr class="file-list-header">
         <th><i [class]="icon_copy"></i> Files that will be created</th>
       </tr>

--- a/src/app/submit/submit.component.html
+++ b/src/app/submit/submit.component.html
@@ -5,9 +5,13 @@
   </span>
 
   <span class="col-auto">
+    <span class="bulk-label">Overview of actions</span>
+  </span>
+
+  <span class="col-auto">
     <button pButton pRipple type="button" [hidden]="!done || !hasAccessToCompute" class="p-button-sm p-button-raised p-button-secondary" (click)="goToCompute()" title="Go to compute">Go to compute&nbsp;<i class="pi pi-angle-double-right"></i></button>
     <button pButton pRipple type="button" [attr.hidden]="done ? null : ''" class="p-button-sm p-button-raised p-button-secondary" (click)="goToDataset()" title="Go to RDR to see the resulting dataset">Go to dataset&nbsp;<i class="pi pi-angle-double-right"></i></button>
-    <button pButton pRipple type="button" [attr.hidden]="done ? '' : null" class="p-button-sm p-button-raised p-button-secondary" (click)="submit()" title="Initiate selected changes" [attr.disabled]="disabled ? '' : null">Submit&nbsp;<i class="pi pi-angle-double-right"></i></button>
+    <button pButton pRipple type="button" [attr.hidden]="done ? '' : null" class="p-button-sm p-button-raised p-button-primary" (click)="submit()" title="Initiate selected changes" [attr.disabled]="disabled ? '' : null">Submit&nbsp;<i class="pi pi-angle-double-right"></i></button>
   </span>
 </div>
 

--- a/src/app/submit/submit.component.html
+++ b/src/app/submit/submit.component.html
@@ -31,28 +31,6 @@
 
 <table class="table">
   <tbody>
-    <tr [hidden]="!metadata">
-      <th><i [class]="icon_copy"></i> Metadata that will be copied</th>
-    </tr>
-    <tr class="file-list-header" [hidden]="!metadata">
-      <p-treeTable [value]="rootNodeChildren">
-        <ng-template pTemplate="header">
-          <tr>
-            <th style="text-align: left;">Field</th>
-            <th>Value</th>
-            <th class="icon_col" style="text-align: right;">
-              <button pButton pRipple label='' type="button"
-                class="p-button-sm p-button-outlined p-button-secondary" (click)="toggleAction()"><i
-              [class]="action()"></i></button>
-            </th>
-          </tr>
-        </ng-template>
-        <ng-template pTemplate="body" let-rowNode let-rowData="rowData">
-          <tr app-metadatafield [field]="rowData" [rowNodeMap]="rowNodeMap" [rowNode]="rowNode"
-            [style]="rowClass(rowData)">
-          </ng-template>
-        </p-treeTable>
-      </tr>
       <tr class="file-list-header">
         <th><i [class]="icon_copy"></i> Files that will be created</th>
       </tr>

--- a/src/app/submit/submit.component.spec.ts
+++ b/src/app/submit/submit.component.spec.ts
@@ -1,5 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { of, throwError } from 'rxjs';
 import { Router } from '@angular/router';
@@ -48,15 +51,23 @@ describe('SubmitComponent', () => {
     };
 
     submitServiceStub = {
-      submit: jasmine.createSpy('submit').and.returnValue(of({ status: 'OK', datasetUrl: 'http://example.com' })),
+      submit: jasmine
+        .createSpy('submit')
+        .and.returnValue(
+          of({ status: 'OK', datasetUrl: 'http://example.com' }),
+        ),
     };
 
     datasetServiceStub = {
-      newDataset: jasmine.createSpy('newDataset').and.returnValue(of({ persistentId: 'doi:new' })),
+      newDataset: jasmine
+        .createSpy('newDataset')
+        .and.returnValue(of({ persistentId: 'doi:new' })),
     };
 
     dataUpdatesServiceStub = {
-      updateData: jasmine.createSpy('updateData').and.returnValue(of({ data: undefined } as any)),
+      updateData: jasmine
+        .createSpy('updateData')
+        .and.returnValue(of({ data: undefined } as any)),
     };
 
     notificationServiceStub = {
@@ -105,7 +116,11 @@ describe('SubmitComponent', () => {
     const files: Datafile[] = [
       { action: Fileaction.Copy, status: Filestatus.Equal } as any,
       { action: Fileaction.Update, status: Filestatus.Equal } as any,
-      { action: Fileaction.Delete, status: Filestatus.New, attributes: { remoteHashType: '', remoteHash: '' } } as any,
+      {
+        action: Fileaction.Delete,
+        status: Filestatus.New,
+        attributes: { remoteHashType: '', remoteHash: '' },
+      } as any,
       { action: Fileaction.Ignore, status: Filestatus.Equal } as any,
     ];
     await component.setData(files);
@@ -129,7 +144,7 @@ describe('SubmitComponent', () => {
       { action: Fileaction.Ignore, status: Filestatus.Equal } as any,
     ];
     await component.continueSubmit();
-    expect((routerStub.navigate as any)).toHaveBeenCalledWith(['/connect']);
+    expect(routerStub.navigate as any).toHaveBeenCalledWith(['/connect']);
   });
 
   it('continueSubmit should call submit service and mark submitted on OK', async () => {
@@ -151,25 +166,28 @@ describe('SubmitComponent', () => {
   });
 
   it('getDataSubscription should navigate to /connect and show error on failure', () => {
-    (dataUpdatesServiceStub.updateData as jasmine.Spy).and.returnValue(throwError(() => ({ error: 'boom' })));
+    (dataUpdatesServiceStub.updateData as jasmine.Spy).and.returnValue(
+      throwError(() => ({ error: 'boom' })),
+    );
     component.getDataSubscription();
     expect(notificationServiceStub.showError).toHaveBeenCalled();
-    expect((routerStub.navigate as any)).toHaveBeenCalledWith(['/connect']);
+    expect(routerStub.navigate as any).toHaveBeenCalledWith(['/connect']);
   });
 
   it('goToCompute should navigate to compute route with pid', () => {
     component.pid = 'doi:abc';
     component.goToCompute();
-    expect((routerStub.navigate as any)).toHaveBeenCalledWith(['/compute'], { queryParams: { pid: 'doi:abc' } });
+    expect(routerStub.navigate as any).toHaveBeenCalledWith(['/compute'], {
+      queryParams: { pid: 'doi:abc' },
+    });
   });
 
   it('back should call Location.back', () => {
     component.back();
-    expect((locationStub.back as any)).toHaveBeenCalled();
+    expect(locationStub.back as any).toHaveBeenCalled();
   });
 
   it('sendMails should return plugin service value', () => {
     expect(component.sendMails()).toBeTrue();
   });
-
 });

--- a/src/app/submit/submit.component.spec.ts
+++ b/src/app/submit/submit.component.spec.ts
@@ -1,41 +1,99 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from '@angular/common/http';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of, throwError } from 'rxjs';
 import { Router } from '@angular/router';
 
 import { SubmitComponent } from './submit.component';
 import { DataStateService } from '../data.state.service';
+import { CredentialsService } from '../credentials.service';
+import { DataService } from '../data.service';
+import { SubmitService } from '../submit.service';
+import { DatasetService } from '../dataset.service';
+import { DataUpdatesService } from '../data.updates.service';
+import { NotificationService } from '../shared/notification.service';
+import { PluginService } from '../plugin.service';
+import { Location } from '@angular/common';
+import { Fileaction, Filestatus, Datafile } from '../models/datafile';
 
 describe('SubmitComponent', () => {
   let component: SubmitComponent;
   let fixture: ComponentFixture<SubmitComponent>;
-  let routerNavigateSpy: jasmine.Spy;
   let dataStateStub: Partial<DataStateService>;
+  let credentialsStub: any;
+  let dataServiceStub: any;
+  let submitServiceStub: any;
+  let datasetServiceStub: any;
+  let dataUpdatesServiceStub: any;
+  let notificationServiceStub: any;
+  let pluginServiceStub: any;
+  let routerStub: any;
+  let locationStub: any;
 
   beforeEach(async () => {
-    const routerStub = {
+    dataStateStub = {
+      getCurrentValue: () => ({ id: 'doi:123', data: [] }),
+    };
+
+    credentialsStub = {
+      credentials: {
+        plugin: 'other',
+        dataverse_token: 'dv-token',
+        dataset_id: undefined,
+      },
+    };
+
+    dataServiceStub = {
+      checkAccessToQueue: () => of({ access: false }),
+    };
+
+    submitServiceStub = {
+      submit: jasmine.createSpy('submit').and.returnValue(of({ status: 'OK', datasetUrl: 'http://example.com' })),
+    };
+
+    datasetServiceStub = {
+      newDataset: jasmine.createSpy('newDataset').and.returnValue(of({ persistentId: 'doi:new' })),
+    };
+
+    dataUpdatesServiceStub = {
+      updateData: jasmine.createSpy('updateData').and.returnValue(of({ data: undefined } as any)),
+    };
+
+    notificationServiceStub = {
+      showError: jasmine.createSpy('showError'),
+    };
+
+    pluginServiceStub = {
+      sendMails: () => true,
+    };
+
+    routerStub = {
       navigate: jasmine.createSpy('navigate'),
     } as unknown as Router;
-    dataStateStub = {
-      getCurrentValue: () =>
-        ({ id: 'collectionId:New Dataset', data: [] }) as any,
-    };
+
+    locationStub = {
+      back: jasmine.createSpy('back'),
+    } as unknown as Location;
     await TestBed.configureTestingModule({
       imports: [SubmitComponent],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
-        { provide: Router, useValue: routerStub },
         { provide: DataStateService, useValue: dataStateStub },
+        { provide: CredentialsService, useValue: credentialsStub },
+        { provide: DataService, useValue: dataServiceStub },
+        { provide: SubmitService, useValue: submitServiceStub },
+        { provide: DatasetService, useValue: datasetServiceStub },
+        { provide: DataUpdatesService, useValue: dataUpdatesServiceStub },
+        { provide: NotificationService, useValue: notificationServiceStub },
+        { provide: PluginService, useValue: pluginServiceStub },
+        { provide: Router, useValue: routerStub },
+        { provide: Location, useValue: locationStub },
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SubmitComponent);
     component = fixture.componentInstance;
-    routerNavigateSpy = TestBed.inject(Router).navigate as jasmine.Spy;
     fixture.detectChanges();
   });
 
@@ -43,7 +101,75 @@ describe('SubmitComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should redirect to metadata-selector when pid indicates new dataset on init', () => {
-    expect(routerNavigateSpy).toHaveBeenCalledWith(['/metadata-selector']);
+  it('should categorize files into created/updated/deleted on setData', async () => {
+    const files: Datafile[] = [
+      { action: Fileaction.Copy, status: Filestatus.Equal } as any,
+      { action: Fileaction.Update, status: Filestatus.Equal } as any,
+      { action: Fileaction.Delete, status: Filestatus.New, attributes: { remoteHashType: '', remoteHash: '' } } as any,
+      { action: Fileaction.Ignore, status: Filestatus.Equal } as any,
+    ];
+    await component.setData(files);
+    expect(component.created.length).toBe(1);
+    expect(component.updated.length).toBe(1);
+    expect(component.deleted.length).toBe(1);
+    // deleted file should have unknown hash type set when missing
+    expect(component.deleted[0].attributes?.remoteHashType).toBe('unknown');
+    // flattened data is concatenation of the three lists
+    expect(component.data.length).toBe(3);
   });
+
+  it('submit should show popup when plugin is not globus', () => {
+    credentialsStub.credentials.plugin = 'other';
+    component.submit();
+    expect(component.popup).toBeTrue();
+  });
+
+  it('continueSubmit should navigate to /connect when no changes selected', async () => {
+    component.data = [
+      { action: Fileaction.Ignore, status: Filestatus.Equal } as any,
+    ];
+    await component.continueSubmit();
+    expect((routerStub.navigate as any)).toHaveBeenCalledWith(['/connect']);
+  });
+
+  it('continueSubmit should call submit service and mark submitted on OK', async () => {
+    const files: Datafile[] = [
+      { action: Fileaction.Copy, status: Filestatus.Equal } as any,
+    ];
+    await component.setData(files);
+    await component.continueSubmit();
+    expect(submitServiceStub.submit).toHaveBeenCalled();
+    expect(component.submitted).toBeTrue();
+    expect(component.datasetUrl).toBe('http://example.com');
+  });
+
+  it('newDataset should set pid and return true on success', async () => {
+    const ok = await component.newDataset('collection-1');
+    expect(ok).toBeTrue();
+    expect(component.pid).toBe('doi:new');
+    expect(credentialsStub.credentials.dataset_id).toBe('doi:new');
+  });
+
+  it('getDataSubscription should navigate to /connect and show error on failure', () => {
+    (dataUpdatesServiceStub.updateData as jasmine.Spy).and.returnValue(throwError(() => ({ error: 'boom' })));
+    component.getDataSubscription();
+    expect(notificationServiceStub.showError).toHaveBeenCalled();
+    expect((routerStub.navigate as any)).toHaveBeenCalledWith(['/connect']);
+  });
+
+  it('goToCompute should navigate to compute route with pid', () => {
+    component.pid = 'doi:abc';
+    component.goToCompute();
+    expect((routerStub.navigate as any)).toHaveBeenCalledWith(['/compute'], { queryParams: { pid: 'doi:abc' } });
+  });
+
+  it('back should call Location.back', () => {
+    component.back();
+    expect((locationStub.back as any)).toHaveBeenCalled();
+  });
+
+  it('sendMails should return plugin service value', () => {
+    expect(component.sendMails()).toBeTrue();
+  });
+
 });

--- a/src/app/submit/submit.component.spec.ts
+++ b/src/app/submit/submit.component.spec.ts
@@ -1,33 +1,49 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
 
 import { SubmitComponent } from './submit.component';
+import { DataStateService } from '../data.state.service';
 
 describe('SubmitComponent', () => {
   let component: SubmitComponent;
   let fixture: ComponentFixture<SubmitComponent>;
+  let routerNavigateSpy: jasmine.Spy;
+  let dataStateStub: Partial<DataStateService>;
 
   beforeEach(async () => {
+    const routerStub = {
+      navigate: jasmine.createSpy('navigate'),
+    } as unknown as Router;
+    dataStateStub = {
+      getCurrentValue: () =>
+        ({ id: 'collectionId:New Dataset', data: [] }) as any,
+    };
     await TestBed.configureTestingModule({
       imports: [SubmitComponent],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
+        { provide: Router, useValue: routerStub },
+        { provide: DataStateService, useValue: dataStateStub },
       ],
-    })
-      // Shallow render to avoid PrimeNG TreeTable internal provider requirements during unit tests
-      .overrideComponent(SubmitComponent, {
-        set: { template: '<div></div>' },
-      })
-      .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(SubmitComponent);
     component = fixture.componentInstance;
+    routerNavigateSpy = TestBed.inject(Router).navigate as jasmine.Spy;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should redirect to metadata-selector when pid indicates new dataset on init', () => {
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['/metadata-selector']);
   });
 });

--- a/src/app/submit/submit.component.ts
+++ b/src/app/submit/submit.component.ts
@@ -103,13 +103,6 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
     const nav = this.router.getCurrentNavigation();
     if (nav?.extras?.state) {
       state = nav.extras.state as { metadata?: Metadata };
-    } else if (
-      typeof window !== 'undefined' &&
-      window.history &&
-      window.history.state
-    ) {
-      // Fallback for environments/tests where Router.getCurrentNavigation is not available
-      state = window.history.state as { metadata?: Metadata };
     }
     if (state?.metadata) {
       this.incomingMetadata = state.metadata;

--- a/src/app/submit/submit.component.ts
+++ b/src/app/submit/submit.component.ts
@@ -91,20 +91,27 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
   hasAccessToCompute = false;
   private incomingMetadata?: Metadata;
 
-  constructor() { }
+  constructor() {}
 
   ngOnInit(): void {
     this.loadData();
     // Capture metadata from navigation state if coming from metadata-selector
     let state: { metadata?: Metadata } | undefined;
-    const routerMaybe = this.router as unknown as { getCurrentNavigation?: () => Navigation | null };
+    const routerMaybe = this.router as unknown as {
+      getCurrentNavigation?: () => Navigation | null;
+    };
     // Use Router.getCurrentNavigation when available
     if (typeof routerMaybe.getCurrentNavigation === 'function') {
       const nav = routerMaybe.getCurrentNavigation?.();
       state = (nav?.extras?.state as { metadata?: Metadata }) || undefined;
-    } else if (typeof history !== 'undefined' && (history as History & { state?: unknown }).state) {
+    } else if (
+      typeof history !== 'undefined' &&
+      (history as History & { state?: unknown }).state
+    ) {
       // Fallback for environments/tests where Router.getCurrentNavigation is not available
-      state = (history as History & { state?: unknown }).state as { metadata?: Metadata };
+      state = (history as History & { state?: unknown }).state as {
+        metadata?: Metadata;
+      };
     }
     if (state?.metadata) {
       this.incomingMetadata = state.metadata;
@@ -128,7 +135,7 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
 
   ngOnDestroy(): void {
     // Clean up all subscriptions
-    this.subscriptions.forEach(sub => sub.unsubscribe());
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
     this.subscriptions.clear();
   }
 
@@ -152,7 +159,9 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
         },
         error: (err) => {
           setTimeout(() => dataSubscription?.unsubscribe(), 0);
-          this.notificationService.showError(`Getting status of data failed: ${err.error}`);
+          this.notificationService.showError(
+            `Getting status of data failed: ${err.error}`,
+          );
           this.router.navigate(['/connect']);
         },
       });
@@ -261,7 +270,9 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
         next: (data: StoreResult) => {
           if (data.status !== 'OK') {
             // this should not happen
-            this.notificationService.showError(`Store failed, status: ${data.status}`);
+            this.notificationService.showError(
+              `Store failed, status: ${data.status}`,
+            );
             this.router.navigate(['/connect']);
           } else {
             this.getDataSubscription();

--- a/src/app/submit/submit.component.ts
+++ b/src/app/submit/submit.component.ts
@@ -97,21 +97,13 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
     this.loadData();
     // Capture metadata from navigation state if coming from metadata-selector
     let state: { metadata?: Metadata } | undefined;
-    const routerMaybe = this.router as unknown as {
-      getCurrentNavigation?: () => Navigation | null;
-    };
-    // Use Router.getCurrentNavigation when available
-    if (typeof routerMaybe.getCurrentNavigation === 'function') {
-      const nav = routerMaybe.getCurrentNavigation?.();
-      state = (nav?.extras?.state as { metadata?: Metadata }) || undefined;
-    } else if (
-      typeof history !== 'undefined' &&
-      (history as History & { state?: unknown }).state
-    ) {
+    // Use Router.getCurrentNavigation when available (only during navigation)
+    const nav = this.router.getCurrentNavigation?.();
+    if (nav?.extras?.state) {
+      state = nav.extras.state as { metadata?: Metadata };
+    } else if (typeof window !== 'undefined' && window.history && window.history.state) {
       // Fallback for environments/tests where Router.getCurrentNavigation is not available
-      state = (history as History & { state?: unknown }).state as {
-        metadata?: Metadata;
-      };
+      state = window.history.state as { metadata?: Metadata };
     }
     if (state?.metadata) {
       this.incomingMetadata = state.metadata;

--- a/src/app/submit/submit.component.ts
+++ b/src/app/submit/submit.component.ts
@@ -100,13 +100,11 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
     // Capture metadata from navigation state if coming from metadata-selector
     let state: { metadata?: Metadata } | undefined;
     // Use Router.getCurrentNavigation when available (only during navigation). In tests/mocks this may be undefined.
-    type RouterWithNav = Router & {
-      getCurrentNavigation?: () => { extras?: { state?: unknown } } | null;
-    };
-    const routerNav = this.router as RouterWithNav;
     const hasGetCurrentNavigation =
-      typeof routerNav.getCurrentNavigation === 'function';
-    const nav = hasGetCurrentNavigation ? routerNav.getCurrentNavigation!() : null;
+      typeof (this.router as any).getCurrentNavigation === 'function';
+    const nav = hasGetCurrentNavigation
+      ? ((this.router as any).getCurrentNavigation() as { extras?: { state?: unknown } } | null)
+      : null;
     if (nav?.extras?.state) {
       state = nav.extras.state as { metadata?: Metadata };
     } else if (

--- a/src/app/submit/submit.component.ts
+++ b/src/app/submit/submit.component.ts
@@ -3,7 +3,7 @@
 import { Component, OnInit, OnDestroy, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { Location } from '@angular/common';
-import { Subscription, firstValueFrom } from 'rxjs';
+import { Subscription } from 'rxjs';
 
 // Services
 import { DataUpdatesService } from '../data.updates.service';
@@ -13,33 +13,26 @@ import { PluginService } from '../plugin.service';
 import { UtilsService } from '../utils.service';
 import { CredentialsService } from '../credentials.service';
 import { DataService } from '../data.service';
-import { DatasetService } from '../dataset.service';
+// import { DatasetService } from '../dataset.service';
 import { NotificationService } from '../shared/notification.service';
 
 // Models
 import { Datafile, Fileaction, Filestatus } from '../models/datafile';
 import { StoreResult } from '../models/store-result';
 import { CompareResult } from '../models/compare-result';
-import { MetadataRequest } from '../models/metadata-request';
-import {
-  Field,
-  Fieldaction,
-  FieldDictonary,
-  Metadata,
-  MetadataField,
-} from '../models/field';
+// import { MetadataRequest } from '../models/metadata-request';
+// import { Field, Fieldaction, FieldDictonary, Metadata, MetadataField } from '../models/field';
 
 // PrimeNG
-import { TreeNode, PrimeTemplate } from 'primeng/api';
+// import { TreeNode, PrimeTemplate } from 'primeng/api';
 import { ButtonDirective, Button } from 'primeng/button';
 import { Ripple } from 'primeng/ripple';
 import { Dialog } from 'primeng/dialog';
 import { Checkbox } from 'primeng/checkbox';
 import { FormsModule } from '@angular/forms';
-import { TreeTableModule } from 'primeng/treetable';
+// import { TreeTableModule } from 'primeng/treetable';
 
 // Components
-import { MetadatafieldComponent } from '../metadatafield/metadatafield.component';
 import { SubmittedFileComponent } from '../submitted-file/submitted-file.component';
 
 // Constants and types
@@ -52,14 +45,13 @@ import { SubscriptionManager } from '../shared/types';
   styleUrls: ['./submit.component.scss'],
   imports: [
     ButtonDirective,
+    Button,
     Ripple,
     Dialog,
     Checkbox,
     FormsModule,
-    PrimeTemplate,
-    Button,
-    TreeTableModule,
-    MetadatafieldComponent,
+    // PrimeTemplate,
+    // TreeTableModule, // no longer used here
     SubmittedFileComponent,
   ],
 })
@@ -73,7 +65,7 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
   private readonly utils = inject(UtilsService);
   dataService = inject(DataService);
   private readonly credentialsService = inject(CredentialsService);
-  private readonly datasetService = inject(DatasetService);
+  // private readonly datasetService = inject(DatasetService);
   private readonly notificationService = inject(NotificationService);
 
   // Subscriptions for cleanup
@@ -101,18 +93,17 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
   popup = false;
   hasAccessToCompute = false;
 
-  metadata?: Metadata;
+  // Metadata selection is handled in MetadataSelectorComponent
 
-  root?: TreeNode<Field>;
-  rootNodeChildren: TreeNode<Field>[] = [];
-  rowNodeMap: Map<string, TreeNode<Field>> = new Map<string, TreeNode<Field>>();
-
-  id = 0;
-
-  constructor() { }
+  constructor() {}
 
   ngOnInit(): void {
     this.loadData();
+    // If somehow navigated directly while creating a new dataset, send to metadata selection first
+    if (this.pid.endsWith(':New Dataset')) {
+      this.router.navigate(['/metadata-selector']);
+      return;
+    }
     const subscription = this.dataService
       .checkAccessToQueue(
         '',
@@ -132,7 +123,7 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
 
   ngOnDestroy(): void {
     // Clean up all subscriptions
-    this.subscriptions.forEach(sub => sub.unsubscribe());
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
     this.subscriptions.clear();
   }
 
@@ -154,7 +145,9 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
         },
         error: (err) => {
           dataSubscription?.unsubscribe();
-          this.notificationService.showError(`Getting status of data failed: ${err.error}`);
+          this.notificationService.showError(
+            `Getting status of data failed: ${err.error}`,
+          );
           this.router.navigate(['/connect']);
         },
       });
@@ -183,30 +176,6 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
     this.updated = this.toUpdate();
     this.deleted = this.toDelete();
     this.data = [...this.created, ...this.updated, ...this.deleted];
-    if (this.pid.endsWith(':New Dataset')) {
-      const credentials = this.credentialsService.credentials;
-      const req: MetadataRequest = {
-        pluginId: credentials.pluginId,
-        plugin: credentials.plugin,
-        repoName: credentials.repo_name,
-        url: credentials.url,
-        option: credentials.option,
-        user: credentials.user,
-        token: credentials.token,
-        dvToken: credentials.dataverse_token,
-        compareResult: this.dataStateService.getCurrentValue(),
-      };
-      this.metadata = await firstValueFrom(
-        this.datasetService.getMetadata(req),
-      );
-      const rowDataMap = this.mapFields(this.metadata);
-      rowDataMap.forEach((v) => this.addChild(v, rowDataMap));
-      this.root = rowDataMap.get('');
-      this.rowNodeMap = rowDataMap;
-      if (this.root?.children) {
-        this.rootNodeChildren = this.root.children;
-      }
-    }
   }
 
   toCreate(): Datafile[] {
@@ -271,14 +240,7 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
       return;
     }
 
-    if (this.pid.endsWith(':New Dataset')) {
-      const ids = this.pid.split(':');
-      const ok = await this.newDataset(ids[0]);
-      if (!ok) {
-        this.disabled = false;
-        return;
-      }
-    }
+    // New dataset creation is handled in MetadataSelectorComponent
 
     const httpSubscription = this.submitService
       .submit(selected, this.sendEmailOnSuccess)
@@ -286,7 +248,9 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
         next: (data: StoreResult) => {
           if (data.status !== 'OK') {
             // this should not happen
-            this.notificationService.showError(`Store failed, status: ${data.status}`);
+            this.notificationService.showError(
+              `Store failed, status: ${data.status}`,
+            );
             this.router.navigate(['/connect']);
           } else {
             this.getDataSubscription();
@@ -318,241 +282,7 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
     return this.pluginService.sendMails();
   }
 
-  async newDataset(collectionId: string): Promise<boolean> {
-    const metadata = this.filteredMetadata();
-    const data = await firstValueFrom(
-      this.datasetService.newDataset(
-        collectionId,
-        this.credentialsService.credentials.dataverse_token,
-        metadata,
-      ),
-    );
-    if (data.persistentId !== undefined && data.persistentId !== '') {
-      this.pid = data.persistentId;
-      this.credentialsService.credentials.dataset_id = data.persistentId;
-      return true;
-    } else {
-      this.notificationService.showError('Creating new dataset failed');
-      return false;
-    }
-  }
+  // New dataset creation moved to MetadataSelectorComponent
 
-  action(): string {
-    if (this.root) {
-      return MetadatafieldComponent.actionIcon(this.root);
-    }
-    return MetadatafieldComponent.icon_ignore;
-  }
-
-  toggleAction(): void {
-    if (this.root) {
-      MetadatafieldComponent.toggleNodeAction(this.root);
-    }
-  }
-
-  rowClass(field: Field): string {
-    switch (field.action) {
-      case Fieldaction.Ignore:
-        return '';
-      case Fieldaction.Copy:
-        return 'background-color: #c3e6cb; color: black';
-      case Fieldaction.Custom:
-        return 'background-color: #FFFAA0; color: black';
-    }
-    return '';
-  }
-
-  addChild(v: TreeNode<Field>, rowDataMap: Map<string, TreeNode<Field>>): void {
-    if (v.data?.id == '') {
-      return;
-    }
-    const parent = rowDataMap.get(v.data!.parent!)!;
-    const children = parent.children ? parent.children : [];
-    parent.children = children.concat(v);
-  }
-
-  mapFields(metadata: Metadata): Map<string, TreeNode<Field>> {
-    const rootData: Field = {
-      id: '',
-      parent: '',
-      name: '',
-      action: Fieldaction.Copy,
-    };
-
-    const rowDataMap: Map<string, TreeNode<Field>> = new Map<
-      string,
-      TreeNode<Field>
-    >();
-    rowDataMap.set('', {
-      data: rootData,
-    });
-
-    metadata.datasetVersion.metadataBlocks.citation.fields.forEach((d) => {
-      this.addToDataMap(d, '', rowDataMap);
-    });
-    return rowDataMap;
-  }
-
-  private addToDataMap(
-    d: MetadataField,
-    parent: string,
-    rowDataMap: Map<string, TreeNode<Field>>,
-  ) {
-    if (
-      d.value &&
-      Array.isArray(d.value) &&
-      d.value.length > 0 &&
-      typeof d.value[0] === 'string'
-    ) {
-      let content = d.value[0];
-      for (let i = 1; i < d.value.length; i++) {
-        content = `${content}, ${d.value[i]}`;
-      }
-      const id = `${this.id++}`;
-      d.id = id;
-      const data: Field = {
-        id: id,
-        parent: parent,
-        name: d.typeName,
-        action: Fieldaction.Copy,
-        leafValue: content,
-        field: d,
-      };
-      rowDataMap.set(id, {
-        data: data,
-      });
-    } else if (d.value && typeof d.value !== 'string') {
-      (d.value as FieldDictonary[]).forEach((v) => {
-        const id = `${this.id++}`;
-        const data: Field = {
-          id: id,
-          parent: parent,
-          name: d.typeName,
-          action: Fieldaction.Copy,
-          field: v,
-        };
-        rowDataMap.set(id, {
-          data: data,
-        });
-        this.mapChildField(id, v, rowDataMap);
-      });
-    } else {
-      const id = `${this.id++}`;
-      d.id = id;
-      const data: Field = {
-        id: id,
-        parent: parent,
-        name: d.typeName,
-        action: Fieldaction.Copy,
-        leafValue: d.value,
-        field: d,
-      };
-      rowDataMap.set(id, {
-        data: data,
-      });
-    }
-  }
-
-  mapChildField(
-    parent: string,
-    fieldDictonary: FieldDictonary,
-    rowDataMap: Map<string, TreeNode<Field>>,
-  ) {
-    Object.values(fieldDictonary).forEach((d) => {
-      this.addToDataMap(d, parent, rowDataMap);
-    });
-  }
-
-  filteredMetadata(): Metadata | undefined {
-    if (
-      !this.metadata ||
-      !this.rootNodeChildren ||
-      this.rootNodeChildren.length === 0
-    ) {
-      return undefined;
-    }
-    let res: MetadataField[] = [];
-    this.metadata.datasetVersion.metadataBlocks.citation.fields.forEach((f) => {
-      if (this.rowNodeMap.get(f.id!)?.data?.action == Fieldaction.Copy) {
-        const field: MetadataField = {
-          expandedvalue: f.expandedvalue,
-          multiple: f.multiple,
-          typeClass: f.typeClass,
-          typeName: f.typeName,
-          value: f.value,
-        };
-        res = res.concat(field);
-      } else if (
-        f.value &&
-        Array.isArray(f.value) &&
-        f.value.length > 0 &&
-        typeof f.value[0] !== 'string'
-      ) {
-        const dicts = this.customValue(f.value as FieldDictonary[]);
-        if (dicts.length > 0) {
-          const field: MetadataField = {
-            expandedvalue: f.expandedvalue,
-            multiple: f.multiple,
-            typeClass: f.typeClass,
-            typeName: f.typeName,
-            value: dicts,
-          };
-          res = res.concat(field);
-        }
-      }
-    });
-    return {
-      datasetVersion: {
-        metadataBlocks: {
-          citation: {
-            displayName:
-              this.metadata.datasetVersion.metadataBlocks.citation.displayName,
-            fields: res,
-            name: this.metadata.datasetVersion.metadataBlocks.citation.name,
-          },
-        },
-      },
-    };
-  }
-
-  customValue(metadataFields: FieldDictonary[]): FieldDictonary[] {
-    let res: FieldDictonary[] = [];
-    metadataFields.forEach((d) => {
-      const dict: FieldDictonary = {};
-      Object.keys(d).forEach((k) => {
-        const f = d[k];
-        if (this.rowNodeMap.get(f.id!)?.data?.action == Fieldaction.Copy) {
-          const field: MetadataField = {
-            expandedvalue: f.expandedvalue,
-            multiple: f.multiple,
-            typeClass: f.typeClass,
-            typeName: f.typeName,
-            value: f.value,
-          };
-          dict[k] = field;
-        } else if (
-          f.value &&
-          Array.isArray(f.value) &&
-          f.value.length > 0 &&
-          typeof f.value[0] !== 'string'
-        ) {
-          const dicts = this.customValue(f.value as FieldDictonary[]);
-          if (dicts.length > 0) {
-            const field: MetadataField = {
-              expandedvalue: f.expandedvalue,
-              multiple: f.multiple,
-              typeClass: f.typeClass,
-              typeName: f.typeName,
-              value: this.customValue(f.value as FieldDictonary[]),
-            };
-            dict[k] = field;
-          }
-        }
-      });
-      if (Object.keys(dict).length > 0) {
-        res = res.concat(dict);
-      }
-    });
-    return res;
-  }
+  // Metadata helper methods removed; file submission only
 }

--- a/src/app/submit/submit.component.ts
+++ b/src/app/submit/submit.component.ts
@@ -1,7 +1,7 @@
 // Author: Eryk Kulikowski @ KU Leuven (2023). Apache 2.0 License
 
 import { Component, OnInit, OnDestroy, inject } from '@angular/core';
-import { Router, Navigation } from '@angular/router';
+import { Router } from '@angular/router';
 import { Location } from '@angular/common';
 import { Subscription, firstValueFrom } from 'rxjs';
 
@@ -103,7 +103,11 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
     const nav = this.router.getCurrentNavigation?.();
     if (nav?.extras?.state) {
       state = nav.extras.state as { metadata?: Metadata };
-    } else if (typeof window !== 'undefined' && window.history && window.history.state) {
+    } else if (
+      typeof window !== 'undefined' &&
+      window.history &&
+      window.history.state
+    ) {
       // Fallback for environments/tests where Router.getCurrentNavigation is not available
       state = window.history.state as { metadata?: Metadata };
     }

--- a/src/app/submit/submit.component.ts
+++ b/src/app/submit/submit.component.ts
@@ -100,7 +100,7 @@ export class SubmitComponent implements OnInit, OnDestroy, SubscriptionManager {
     // Capture metadata from navigation state if coming from metadata-selector
     let state: { metadata?: Metadata } | undefined;
     // Use Router.getCurrentNavigation when available (only during navigation)
-    const nav = this.router.getCurrentNavigation?.();
+    const nav = this.router.getCurrentNavigation();
     if (nav?.extras?.state) {
       state = nav.extras.state as { metadata?: Metadata };
     } else if (

--- a/src/app/submitted-file/submitted-file.component.ts
+++ b/src/app/submitted-file/submitted-file.component.ts
@@ -22,7 +22,7 @@ export class SubmittedFileComponent implements OnInit {
 
   file(): string {
     const datafile = this.datafile();
-    return `${datafile.path ? `${datafile.path  }/` : ''}${this.datafile().name}`;
+    return `${datafile.path ? `${datafile.path}/` : ''}${this.datafile().name}`;
   }
 
   iconClass(): string {

--- a/src/app/utils.service.ts
+++ b/src/app/utils.service.ts
@@ -46,7 +46,7 @@ export class UtilsService {
     data.forEach((d) => {
       let path = '';
       d.path!.split('/').forEach((folder) => {
-        const id = path != '' ? `${path  }/${  folder}` : folder;
+        const id = path != '' ? `${path}/${folder}` : folder;
         const folderData: Datafile = {
           path: path,
           name: folder,
@@ -59,7 +59,7 @@ export class UtilsService {
         });
         path = id;
       });
-      rowDataMap.set(`${d.id!  }:file`, {
+      rowDataMap.set(`${d.id!}:file`, {
         // avoid collisions between folders and files having the same path and name
         data: d,
       });

--- a/tests/governance/smoke.test.js
+++ b/tests/governance/smoke.test.js
@@ -4,7 +4,7 @@
 
 function main() {
   // Output success message using console.log
-  console.log('Governance smoke: OK');
+  console.log("Governance smoke: OK");
   // Implicit success exit
 }
 


### PR DESCRIPTION
<!-- @ai-generated: true -->

# @ai-tool: Copilot

## Summary

- Split the original submit flow into two standalone components (metadata selector for new datasets, files-only submit) to improve clarity and routing.
- Updated routes and compare component to direct new datasets to metadata selector, existing to submit; fixed PrimeNG imports; added tests; addressed lint.
- Motivation: resolve CI build issues and make governance-friendly, testable units; no behavior regressions for existing datasets.

## AI Provenance (required for AI-assisted changes)

- Prompt: Implement metadata selector component, split submit logic as discussed in conversation; add tests; build, test, lint; create PR via governance context.
- Model: GitHub Copilot gpt-5
- Date: 2025-09-16T13:15:34Z
- Author: @ErykKul
- Role: deployer

## Compliance checklist

- [x] No secrets/PII
- [ ] Transparency notice updated (if user-facing)
- [x] Agent logging enabled (actions/decisions logged)
- [x] Kill-switch / feature flag present for AI features
- [x] No prohibited practices under EU AI Act
- [x] Human oversight retained (required if high-risk or agent mode)
- Risk classification: limited
- Personal data: no
- DPIA: N/A
- Automated decision-making: no
- Agent mode used: no
- GPAI obligations: N/A (if Role: provider)
- Vendor GPAI compliance reviewed: N/A (if Role: deployer)
- [x] License/IP attestation
- Attribution: N/A
- Oversight plan: N/A

### Change-type specifics

- Security review: N/A
- Media assets changed:
    - [ ] AI content labeled
    - C2PA: N/A
- UI changed:
    - [x] Accessibility review (EN 301 549/WCAG)
    - Accessibility statement: N/A
- Deploy/infra changed:
    - Privacy notice: N/A
    - Lawful basis: N/A
    - Retention schedule: N/A
    - NIS2 applicability: N/A
    - Incident response plan: N/A
- Backend/API changed:
    - ASVS: N/A
- Log retention policy: N/A
- Data paths changed:
    - TDM: N/A
    - TDM compliance: N/A

## Tests & Risk

- [x] Unit/integration tests added/updated
- [x] Security scan passed
- Rollback plan: Revert PR; disable feature path by routing to original submit if needed.
- Smoke test: N/A
- [x] Docs updated (if needed)